### PR TITLE
Month-scoped search URLs, source diagnostics and a network probe

### DIFF
--- a/.github/workflows/probe.yml
+++ b/.github/workflows/probe.yml
@@ -1,0 +1,65 @@
+name: Probe sources
+
+# Diagnostics only — never commits anything.
+#
+# Two questions this answers that a sandbox behind a network allowlist cannot:
+#   1. What does a fetched page actually contain? (scrape --diagnose)
+#   2. Is the listing assembled from a JSON endpoint we could query directly,
+#      and how is it paged? (tools/probe_network.py, a real browser)
+#
+# Read the job log. Nothing here is committed, so run it as often as needed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      urls:
+        description: "Space-separated URLs for the network probe (blank = the four season searches)"
+        type: string
+        default: ""
+      max_pages:
+        description: "URLs to visit in the network probe"
+        type: string
+        default: "2"
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Structural diagnosis of fetched pages
+        continue-on-error: true
+        run: |
+          PYTHONPATH=src python3 -m liveaboard.cli scrape \
+            --diagnose --max-pages 3 --warnings 25 \
+            --out /tmp/candidate.json --snapshots /tmp/snapshots
+
+      - name: Install Playwright
+        run: |
+          pip install --quiet playwright
+          playwright install --with-deps chromium
+
+      - name: Network probe
+        continue-on-error: true
+        run: |
+          ARGS=""
+          for u in ${{ inputs.urls }}; do ARGS="$ARGS --url $u"; done
+          python3 tools/probe_network.py $ARGS --max-pages "${{ inputs.max_pages || 2 }}"
+
+      - name: Keep the raw pages
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: probe-snapshots-${{ github.run_id }}
+          path: /tmp/snapshots/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -93,11 +93,11 @@ def cmd_scrape(args: argparse.Namespace) -> int:
     Deliberately does not overwrite the live dataset: a scrape writes a
     candidate file, and promoting it is a separate, reviewable step.
     """
-    fetcher = PoliteFetcher(snapshot_dir=Path(args.snapshots))
+    fetcher = PoliteFetcher(snapshot_dir=Path(args.snapshots), diagnose=args.diagnose)
     selected = [args.source] if args.source else list(ADAPTERS)
 
     combined = ScrapeOutput()
-    failures = 0
+    blocked = 0
 
     for name in selected:
         adapter_cls = ADAPTERS.get(name)
@@ -106,21 +106,33 @@ def cmd_scrape(args: argparse.Namespace) -> int:
             return 2
 
         adapter = adapter_cls(fetcher)
+        if args.max_pages:
+            adapter.max_pages = args.max_pages
         print(f"-- {name}")
         try:
             output = adapter.run()
         except FetchBlocked as exc:
             print(f"   blocked: {exc}", file=sys.stderr)
-            failures += 1
+            blocked += 1
             continue
 
         print(
             f"   {len(output.itineraries)} itineraries, "
             f"{len(output.departures)} departures, {len(output.warnings)} warnings"
         )
-        for warning in output.warnings[: args.limit or 5]:
+        for warning in output.warnings[: args.warnings]:
             print(f"   ! {warning}")
+        remaining = len(output.warnings) - args.warnings
+        if remaining > 0:
+            print(f"   ! ... and {remaining} more")
         combined.extend(output)
+
+    if combined.is_empty:
+        # No candidate file is written, so an empty scrape leaves nothing for
+        # CI to commit. A run that fetched nothing must not look like a quiet
+        # day on which nothing changed.
+        print("scrape produced no itineraries or departures", file=sys.stderr)
+        return 1
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -139,7 +151,7 @@ def cmd_scrape(args: argparse.Namespace) -> int:
         encoding="utf-8",
     )
     print(f"wrote candidate {out}")
-    return 1 if failures and combined.is_empty else 0
+    return 1 if blocked else 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -159,7 +171,20 @@ def main(argv: list[str] | None = None) -> int:
     scrape.add_argument("--source", choices=sorted(ADAPTERS), default=None)
     scrape.add_argument("--out", default=Path("data/candidate.json"), type=Path)
     scrape.add_argument("--snapshots", default=DEFAULT_SNAPSHOTS, type=Path)
-    scrape.add_argument("--limit", type=int, default=0, help="cap warnings printed")
+    scrape.add_argument(
+        "--warnings", type=int, default=10, help="how many warnings to print"
+    )
+    scrape.add_argument(
+        "--max-pages",
+        type=int,
+        default=0,
+        help="cap detail pages fetched per source (0 keeps the adapter default)",
+    )
+    scrape.add_argument(
+        "--diagnose",
+        action="store_true",
+        help="print each page's structure: JSON-LD types, link shapes, price hints",
+    )
     scrape.set_defaults(func=cmd_scrape)
 
     args = parser.parse_args(argv)

--- a/src/liveaboard/scrape/base.py
+++ b/src/liveaboard/scrape/base.py
@@ -73,6 +73,11 @@ class PoliteFetcher:
     delay: float = DEFAULT_DELAY_SECONDS
     timeout: float = 30.0
     user_agent: str = USER_AGENT
+    diagnose: bool = False
+    """Print each page's structure as it is fetched.
+
+    Set when the only channel back from a scrape is a CI log and the snapshot
+    artifact cannot be opened from where the parser is being written."""
     _robots: dict[str, urllib.robotparser.RobotFileParser] = field(default_factory=dict)
     _last_request: dict[str, float] = field(default_factory=dict)
 
@@ -124,6 +129,10 @@ class PoliteFetcher:
 
         result = FetchResult(url=url, status=status, body=body, fetched_at=_now())
         self.snapshot(result)
+        if self.diagnose:
+            from . import diagnose as _diagnose
+
+            print(_diagnose.describe(result), flush=True)
         return result
 
     def snapshot(self, result: FetchResult) -> Path:
@@ -194,8 +203,24 @@ class SourceAdapter(ABC):
     #: is missing when the environment blocks it.
     host: str = ""
 
+    #: Cap on detail pages per run. At a five second crawl delay an uncapped
+    #: listing can outlast the CI job timeout, and a truncated scrape that says
+    #: so beats one that is killed halfway through.
+    max_pages: int = 60
+
     def __init__(self, fetcher: PoliteFetcher) -> None:
         self.fetcher = fetcher
+        self._notes: list[str] = []
+
+    def note(self, message: str) -> None:
+        """Record something the run should report but which is not fatal.
+
+        Discovery is a generator, so it cannot return warnings; without this a
+        404 listing page or an unmatched link pattern disappears silently, and
+        an empty scrape becomes indistinguishable from a site with nothing on
+        it. That is the failure this project can least afford.
+        """
+        self._notes.append(message)
 
     def provenance(self, url: str, retrieved: date | None = None) -> dict[str, Any]:
         return {
@@ -233,14 +258,23 @@ class SourceAdapter(ABC):
         """Fetch and parse everything this adapter can see."""
         self.preflight()
         output = ScrapeOutput()
+        fetched = 0
+
         for url in self.discover():
             try:
                 result = self.fetcher.get(url)
             except FetchBlocked as exc:
                 output.warnings.append(f"skipped {url}: {exc}")
                 continue
+            fetched += 1
             try:
                 output.extend(self.parse(result))
             except ScrapeError as exc:
                 output.warnings.append(f"unparsed {url}: {exc}")
+
+        output.warnings.extend(self._notes)
+        if fetched == 0:
+            output.warnings.append(
+                f"{self.source_id}: no page was fetched at all — check the entry paths"
+            )
         return output

--- a/src/liveaboard/scrape/diagnose.py
+++ b/src/liveaboard/scrape/diagnose.py
@@ -1,0 +1,97 @@
+"""Describe a fetched page's structure without needing to look at the file.
+
+Snapshots are the proper record, but they are a build artifact — when the only
+channel back from a scrape is a CI log, an artifact you cannot download tells
+you nothing. This turns a page into a few lines of structure: what JSON-LD it
+carries, what its links look like, whether a price appears anywhere.
+
+Enough to write a parser against, and small enough to read in a log.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import TYPE_CHECKING
+
+from . import jsonld
+
+if TYPE_CHECKING:
+    from .base import FetchResult
+
+TITLE = re.compile(r"<title[^>]*>(.*?)</title>", re.I | re.S)
+HREF = re.compile(r'href="([^"#?]+)', re.I)
+PRICE_HINT = re.compile(r"(?:€|\$|EUR|USD)\s?\d[\d.,]{2,}", re.I)
+
+TOP_PATTERNS = 12
+SAMPLE_LINKS = 4
+
+
+def _types(html: str) -> Counter[str]:
+    """Count every ``@type`` in the page's structured data."""
+    counts: Counter[str] = Counter()
+    for document in jsonld.extract_blocks(html):
+        for node in jsonld.walk(document):
+            raw = node.get("@type")
+            for name in raw if isinstance(raw, list) else [raw]:
+                if isinstance(name, str):
+                    counts[name] += 1
+    return counts
+
+
+def _link_shapes(html: str) -> tuple[Counter[str], dict[str, str]]:
+    """Group links by their first two path segments.
+
+    The shape is what matters when guessing a detail-page pattern; the sample
+    is what confirms it. ``/diving/egypt/*`` occurring 40 times is the signal
+    that a boat page lives under that prefix.
+    """
+    shapes: Counter[str] = Counter()
+    samples: dict[str, str] = {}
+    for href in HREF.findall(html):
+        path = re.sub(r"^https?://[^/]+", "", href)
+        if not path.startswith("/"):
+            continue
+        parts = [p for p in path.split("/") if p]
+        shape = "/" + "/".join(parts[:2]) + ("/*" if len(parts) > 2 else "")
+        shapes[shape] += 1
+        samples.setdefault(shape, path)
+    return shapes, samples
+
+
+def describe(result: FetchResult) -> str:
+    """Render a compact structural summary of one fetched page."""
+    html = result.body
+    lines: list[str] = []
+
+    title = TITLE.search(html)
+    lines.append(f"   ~ {result.url}")
+    lines.append(f"     status {result.status} · {len(html) / 1024:.0f} KB · digest {result.digest}")
+    if title:
+        clean = re.sub(r"\s+", " ", title.group(1)).strip()
+        lines.append(f"     title: {clean[:90]}")
+
+    types = _types(html)
+    if types:
+        rendered = ", ".join(f"{name}×{n}" for name, n in types.most_common(8))
+        lines.append(f"     json-ld: {rendered}")
+    else:
+        lines.append("     json-ld: none")
+
+    offers = [n for n in jsonld.walk_documents(html) if "offers" in n or "price" in n]
+    if offers:
+        lines.append(f"     json-ld nodes carrying offers/price: {len(offers)}")
+
+    prices = PRICE_HINT.findall(html)
+    if prices:
+        lines.append(f"     price-shaped strings in markup: {len(prices)} (e.g. {prices[0]!r})")
+
+    shapes, samples = _link_shapes(html)
+    if shapes:
+        lines.append("     link shapes:")
+        for shape, count in shapes.most_common(TOP_PATTERNS):
+            lines.append(f"       {count:>4}  {shape:<34} e.g. {samples[shape][:60]}")
+    else:
+        lines.append("     link shapes: none — the page is probably rendered client-side")
+
+    return "\n".join(lines)

--- a/src/liveaboard/scrape/jsonld.py
+++ b/src/liveaboard/scrape/jsonld.py
@@ -80,6 +80,12 @@ def walk(node: Any) -> Iterator[dict[str, Any]]:
             yield from walk(item)
 
 
+def walk_documents(html: str) -> Iterator[dict[str, Any]]:
+    """Yield every JSON-LD node in the page, across all blocks."""
+    for document in extract_blocks(html):
+        yield from walk(document)
+
+
 def of_type(html: str, *types: str) -> list[dict[str, Any]]:
     """Find every JSON-LD node whose ``@type`` matches one of ``types``."""
     wanted = {t.lower() for t in types}

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -16,6 +16,7 @@ To finish it, allowlist the host, run ``python3 -m liveaboard.cli scrape
 
 from __future__ import annotations
 
+import calendar
 import re
 from typing import Any, Iterator
 
@@ -26,19 +27,47 @@ HOST = "www.liveaboard.com"
 
 SEASON_MONTHS = (5, 6, 7, 8)
 SEASON_YEAR = 2027
+DESTINATION = "egypt"
+
+
+def search_paths() -> tuple[str, ...]:
+    """Month-scoped search URLs for the configured season.
+
+    Derived rather than hardcoded so that moving the season moves the crawl
+    with it. These are the right entry point: they return only trips sailing in
+    a given month, so the crawl is already scoped to what the site publishes
+    instead of filtering a whole destination afterwards.
+
+        /diving/search/egypt/may/2027
+        /diving/search/egypt/june/2027   ... and so on
+    """
+    return tuple(
+        f"/diving/search/{DESTINATION}/{calendar.month_name[month].lower()}/{SEASON_YEAR}"
+        for month in SEASON_MONTHS
+    )
+
 
 DESTINATION_PATHS = (
     "/diving/egypt",
     "/diving/egypt/red-sea",
 )
-"""Listing pages to crawl for boat and itinerary links.
+"""Fallback listing pages.
 
-Verify these against the live site before trusting a run: a 404 here yields an
-empty scrape rather than an error, which is the failure mode most likely to go
-unnoticed.
+Both confirmed live and carrying JSON-LD, but neither yielded a priced offer —
+they are destination overviews, not search results. Kept as a secondary source
+of boat links in case the search pages are rendered client-side.
 """
 
-BOAT_LINK = re.compile(r'href="(/diving/egypt/[a-z0-9\-]+)"', re.IGNORECASE)
+BOAT_LINK = re.compile(
+    r'href="(?:https?://(?:www\.)?liveaboard\.com)?(/diving/[a-z0-9\-]+/[a-z0-9\-]+)"',
+    re.IGNORECASE,
+)
+"""Boat detail links, absolute or relative.
+
+The first attempt anchored on a literal ``/diving/egypt/`` prefix and matched
+nothing across two live pages, so this accepts any two-segment ``/diving/``
+path and an optional absolute host.
+"""
 
 
 class LiveaboardComAdapter(SourceAdapter):
@@ -48,20 +77,36 @@ class LiveaboardComAdapter(SourceAdapter):
     host = HOST
 
     def discover(self) -> Iterator[str]:
-        """Crawl the destination listings, then each boat page they link to."""
+        """Crawl the month searches, then each boat page they link to."""
         seen: set[str] = set()
-        for path in DESTINATION_PATHS:
+        found_any = False
+
+        for path in search_paths() + DESTINATION_PATHS:
             url = f"https://{self.host}{path}"
             try:
                 listing = self.fetcher.get(url)
-            except Exception:  # noqa: BLE001 - a dead listing must not end the run
+            except Exception as exc:  # noqa: BLE001 - a dead listing must not end the run
+                # Reported rather than swallowed: a silently skipped listing is
+                # indistinguishable from a site with nothing to sell.
+                self.note(f"listing unavailable {url}: {exc}")
                 continue
             yield url
-            for match in BOAT_LINK.finditer(listing.body):
-                boat_url = f"https://{self.host}{match.group(1)}"
+
+            links = {match.group(1) for match in BOAT_LINK.finditer(listing.body)}
+            if not links:
+                self.note(f"no boat links matched on {url}")
+            for link in sorted(links):
+                boat_url = f"https://{self.host}{link}"
                 if boat_url not in seen:
                     seen.add(boat_url)
+                    found_any = True
+                    if len(seen) > self.max_pages:
+                        self.note(f"stopped at {self.max_pages} boat pages; more were available")
+                        return
                     yield boat_url
+
+        if not found_any:
+            self.note("no boat pages were discovered from any listing")
 
     def parse(self, result: FetchResult) -> ScrapeOutput:
         """Prefer structured data; fall back to markup only when there is none."""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,11 +6,14 @@ import json
 import re
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 from liveaboard.dataset import Dataset, DatasetError
 from liveaboard.render import build_payload, render
-from liveaboard.scrape import jsonld
+from liveaboard.scrape import jsonld, liveaboard_com
+from liveaboard.scrape.base import FetchResult
+from liveaboard.scrape.diagnose import describe
 from liveaboard.scrape.padi_com import PadiComAdapter
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -168,6 +171,61 @@ class TestJsonLd(unittest.TestCase):
     def test_offer_is_extracted(self):
         offer = jsonld.first_offer(jsonld.of_type(self.HTML, "Product")[0])
         self.assertEqual(offer["priceCurrency"], "EUR")
+
+
+class TestSearchPaths(unittest.TestCase):
+    def test_one_path_per_season_month(self):
+        paths = liveaboard_com.search_paths()
+        self.assertEqual(len(paths), len(liveaboard_com.SEASON_MONTHS))
+
+    def test_paths_match_the_published_url_shape(self):
+        self.assertIn("/diving/search/egypt/may/2027", liveaboard_com.search_paths())
+        self.assertIn("/diving/search/egypt/august/2027", liveaboard_com.search_paths())
+
+    def test_boat_links_match_relative_and_absolute(self):
+        """The first attempt anchored on a literal prefix and matched nothing live."""
+        html = (
+            '<a href="/diving/egypt/blue-horizon">a</a>'
+            '<a href="https://www.liveaboard.com/diving/egypt/sea-serpent">b</a>'
+        )
+        found = {m.group(1) for m in liveaboard_com.BOAT_LINK.finditer(html)}
+        self.assertEqual(
+            found, {"/diving/egypt/blue-horizon", "/diving/egypt/sea-serpent"}
+        )
+
+
+class TestDiagnose(unittest.TestCase):
+    HTML = (
+        "<html><head><title>Egypt May 2027</title>"
+        '<script type="application/ld+json">{"@type":"Product",'
+        '"offers":{"@type":"Offer","price":"1200","priceCurrency":"EUR"}}</script>'
+        '</head><body><a href="/diving/egypt/a-boat">x</a>'
+        "<span>From &euro;1,335</span></body></html>"
+    )
+
+    def setUp(self):
+        self.result = FetchResult(
+            url="https://example.test/x",
+            status=200,
+            body=self.HTML,
+            fetched_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        )
+
+    def test_reports_structured_data_types(self):
+        self.assertIn("Product", describe(self.result))
+
+    def test_reports_link_shapes(self):
+        self.assertIn("/diving/egypt/*", describe(self.result))
+
+    def test_flags_a_client_rendered_page(self):
+        """No links at all is the signature of a listing built in the browser."""
+        bare = FetchResult(
+            url="https://example.test/y",
+            status=200,
+            body="<html><body><div id=root></div></body></html>",
+            fetched_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        )
+        self.assertIn("client-side", describe(bare))
 
 
 class TestRequirementExtraction(unittest.TestCase):

--- a/tools/probe_network.py
+++ b/tools/probe_network.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Watch what a search page actually asks the network for.
+
+If a listing is assembled client-side, the HTML is the wrong thing to parse:
+somewhere behind it is a JSON endpoint returning the same trips in a form that
+needs no scraping at all. This drives a real browser at the page, records every
+XHR and fetch, and reports the shape of any JSON that comes back.
+
+Run it when a scrape finds live pages but no data on them — the answer is
+usually that the data arrives after the HTML does.
+
+**Not part of the package.** It needs Playwright, and the library it probes for
+is deliberately dependency-free. It lives in tools/ and runs in CI only.
+
+    python3 tools/probe_network.py [--url URL ...] [--max-pages N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+DEFAULT_URLS = [
+    "https://www.liveaboard.com/diving/search/egypt/may/2027",
+    "https://www.liveaboard.com/diving/search/egypt/june/2027",
+    "https://www.liveaboard.com/diving/search/egypt/july/2027",
+    "https://www.liveaboard.com/diving/search/egypt/august/2027",
+]
+
+INTERESTING = {"xhr", "fetch"}
+
+# Query keys worth calling out: these are how a listing endpoint is usually
+# paged, and paging is the immediate blocker on August's three pages.
+PAGING_KEYS = ("page", "offset", "start", "limit", "per_page", "size", "cursor")
+
+PRICE_KEY = re.compile(r"price|cost|amount|fare|rate", re.I)
+
+
+def shape(value: Any, depth: int = 0) -> str:
+    """Summarise a JSON value's structure rather than dumping its content."""
+    pad = "  " * depth
+    if isinstance(value, dict):
+        if depth >= 2:
+            return f"{{{len(value)} keys}}"
+        lines = []
+        for key, item in list(value.items())[:14]:
+            lines.append(f"{pad}  {key}: {shape(item, depth + 1)}")
+        more = len(value) - 14
+        if more > 0:
+            lines.append(f"{pad}  ... {more} more keys")
+        return "{\n" + "\n".join(lines) + f"\n{pad}}}"
+    if isinstance(value, list):
+        if not value:
+            return "[] (empty)"
+        return f"[{len(value)} items] first = {shape(value[0], depth + 1)}"
+    if isinstance(value, str):
+        return f"str({value[:40]!r})" if len(value) > 40 else f"str({value!r})"
+    return type(value).__name__
+
+
+def describe_json(payload: Any) -> list[str]:
+    """Report the parts of a JSON response a parser would actually want."""
+    lines = [shape(payload)]
+
+    # Find the biggest list in the response: on a search endpoint that is
+    # almost always the results array.
+    biggest: tuple[int, str, list] | None = None
+
+    def walk(node: Any, path: str) -> None:
+        nonlocal biggest
+        if isinstance(node, list):
+            if biggest is None or len(node) > biggest[0]:
+                biggest = (len(node), path, node)
+            for item in node[:1]:
+                walk(item, f"{path}[]")
+        elif isinstance(node, dict):
+            for key, item in node.items():
+                walk(item, f"{path}.{key}" if path else key)
+
+    walk(payload, "")
+    if biggest and biggest[0] > 1 and isinstance(biggest[2][0], dict):
+        count, path, items = biggest
+        record = items[0]
+        lines.append(f"    likely results array: {path or '<root>'} ({count} items)")
+        lines.append(f"    record keys: {', '.join(sorted(record)[:25])}")
+        priced = [k for k in record if PRICE_KEY.search(k)]
+        if priced:
+            lines.append(f"    price-ish keys: {', '.join(priced)}")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", action="append", default=None)
+    parser.add_argument("--max-pages", type=int, default=2, help="URLs to visit")
+    parser.add_argument("--executable", default=None, help="chromium binary path")
+    args = parser.parse_args()
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("playwright is not installed: pip install playwright && playwright install chromium")
+        return 2
+
+    urls = (args.url or DEFAULT_URLS)[: args.max_pages]
+    launch: dict[str, Any] = {"args": ["--no-sandbox"]}
+    if args.executable:
+        launch["executable_path"] = args.executable
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(**launch)
+        for url in urls:
+            print(f"\n{'=' * 78}\n{url}\n{'=' * 78}")
+            probe_one(browser, url)
+        browser.close()
+    return 0
+
+
+def probe_one(browser: Any, url: str) -> None:
+    page = browser.new_page(viewport={"width": 1400, "height": 1000})
+    calls: list[dict[str, Any]] = []
+
+    def on_response(response: Any) -> None:
+        request = response.request
+        if request.resource_type not in INTERESTING:
+            return
+        entry = {
+            "method": request.method,
+            "url": response.url,
+            "status": response.status,
+            "type": (response.headers or {}).get("content-type", ""),
+            "body": None,
+        }
+        if "json" in entry["type"]:
+            try:
+                entry["body"] = response.json()
+            except Exception:  # noqa: BLE001 - a body we cannot read is still worth listing
+                pass
+        calls.append(entry)
+
+    page.on("response", on_response)
+
+    try:
+        page.goto(url, wait_until="networkidle", timeout=60000)
+    except Exception as exc:  # noqa: BLE001 - report and continue to the next URL
+        print(f"  navigation failed: {exc}")
+        page.close()
+        return
+
+    print(f"  title: {page.title()[:100]}")
+    print(f"  final url: {page.url}")
+
+    html = page.content()
+    print(f"  rendered size: {len(html) / 1024:.0f} KB")
+
+    # Does anything on the page look like a paginator?
+    paging = page.eval_on_selector_all(
+        "a[href*='page'], [class*='pagin'] a, [class*='Pagin'] a",
+        "els => els.map(e => e.getAttribute('href')).filter(Boolean).slice(0, 12)",
+    )
+    print(f"  pagination links: {paging if paging else 'none found in DOM'}")
+
+    if not calls:
+        print("  no XHR/fetch calls — the listing is server-rendered, parse the HTML")
+        page.close()
+        return
+
+    print(f"\n  {len(calls)} XHR/fetch calls:")
+    for call in calls:
+        parsed = urlparse(call["url"])
+        query = parsed.query
+        flags = [k for k in PAGING_KEYS if f"{k}=" in query]
+        marker = f"  [paging: {', '.join(flags)}]" if flags else ""
+        print(f"    {call['method']:5} {call['status']} {parsed.netloc}{parsed.path}{marker}")
+        if query:
+            print(f"          ?{query[:180]}")
+
+    for call in calls:
+        if call["body"] is None:
+            continue
+        print(f"\n  --- JSON from {urlparse(call['url']).path} ---")
+        for line in describe_json(call["body"]):
+            print(f"  {line}")
+
+    page.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Acts on what the first live scrape ([run 33082860956](https://github.com/PaludaNCode/Liveaboard/actions/runs/33082860956)) told us.

## What that run revealed

Both hosts are reachable and `robots.txt` permits us — but the scrape produced nothing. The destination pages carried JSON-LD without priced offers, the boat-link pattern matched nothing across two real pages, and padi.com emitted **no warnings at all** because both entry paths 404'd into a bare `except`.

## Entry points

Crawl `/diving/search/egypt/<month>/<year>` instead of the destination overviews — derived from `SEASON_MONTHS`/`SEASON_YEAR`, so moving the season moves the crawl. Destination pages stay as a fallback. The boat-link pattern now accepts absolute URLs and any two-segment `/diving/` path, since the literal-prefix version matched nothing live.

## Silent failures, all three of them

- Discovery is a generator and could not report anything, so a 404 listing or an unmatched link pattern simply vanished. Adapters now record notes that `run()` merges into warnings, and a source that fetched zero pages says so explicitly.
- **An empty scrape returned success and CI committed an empty candidate file** (`0157a3d`). It now writes no candidate and exits non-zero, so a run that fetched nothing can no longer look like a quiet day. This was the concern in #5, confirmed in practice.
- Detail pages are capped per source. At a five-second crawl delay an uncapped listing can outlast the job timeout; truncating and saying so beats being killed halfway through.

## Diagnostics

The snapshot artifact can't be opened from a sandbox behind a network allowlist, so the log has to carry the structure instead.

- `scrape --diagnose` prints each page's JSON-LD types, link shapes and price hints.
- `tools/probe_network.py` drives a real browser and reports every XHR/fetch with the shape of any JSON returned — to establish whether the listing is server-rendered or backed by a queryable endpoint, and how it pages. August reportedly has three pages, and this is what will show how paging is expressed. Kept out of the package: it needs Playwright and the library is deliberately dependency-free.
- `probe.yml` runs both on demand and commits nothing.

`--limit` is renamed `--warnings`; it only ever capped printed warnings but read like a page cap.

66 tests, up from 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_