### PR TITLE
Parse departures from Event nodes, scope the crawl, walk pagination

### DIFF
--- a/src/liveaboard/scrape/base.py
+++ b/src/liveaboard/scrape/base.py
@@ -80,6 +80,14 @@ class PoliteFetcher:
     artifact cannot be opened from where the parser is being written."""
     _robots: dict[str, urllib.robotparser.RobotFileParser] = field(default_factory=dict)
     _last_request: dict[str, float] = field(default_factory=dict)
+    _cache: dict[str, FetchResult] = field(default_factory=dict)
+    """Responses already fetched in this run.
+
+    Listing pages are read twice by design — once by ``discover`` to find links,
+    once by ``run`` to parse — and at a five second crawl delay paying for that
+    twice is both slow and rude. The cache lives for one run only; the daily
+    schedule is what makes data fresh, not re-fetching within a single pass.
+    """
 
     def _robots_for(self, url: str) -> urllib.robotparser.RobotFileParser:
         host = urlparse(url).netloc
@@ -111,6 +119,16 @@ class PoliteFetcher:
 
     def get(self, url: str) -> FetchResult:
         """Fetch one URL, refusing if robots.txt disallows it."""
+        cached = self._cache.get(url)
+        if cached is not None:
+            return FetchResult(
+                url=cached.url,
+                status=cached.status,
+                body=cached.body,
+                fetched_at=cached.fetched_at,
+                from_cache=True,
+            )
+
         if not self.allowed(url):
             raise FetchBlocked(f"robots.txt disallows {url}")
 
@@ -128,6 +146,7 @@ class PoliteFetcher:
             raise FetchBlocked(f"{url} unreachable: {exc.reason}") from exc
 
         result = FetchResult(url=url, status=status, body=body, fetched_at=_now())
+        self._cache[url] = result
         self.snapshot(result)
         if self.diagnose:
             from . import diagnose as _diagnose

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import calendar
 import re
+from datetime import date
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 from .base import FetchResult, ScrapeError, ScrapeOutput, SourceAdapter
 from . import jsonld
@@ -47,27 +49,47 @@ def search_paths() -> tuple[str, ...]:
     )
 
 
+MAX_SEARCH_PAGES = 5
+"""Result pages to walk per month.
+
+August is known to run to three. Five leaves headroom without crawling
+forever; the walk stops early as soon as a page yields no new boats.
+"""
+
 DESTINATION_PATHS = (
     "/diving/egypt",
     "/diving/egypt/red-sea",
 )
 """Fallback listing pages.
 
-Both confirmed live and carrying JSON-LD, but neither yielded a priced offer —
-they are destination overviews, not search results. Kept as a secondary source
-of boat links in case the search pages are rendered client-side.
+Both confirmed live, but neither yielded a priced offer — they are destination
+overviews, not search results. Kept as a secondary source of boat links.
 """
 
 BOAT_LINK = re.compile(
-    r'href="(?:https?://(?:www\.)?liveaboard\.com)?(/diving/[a-z0-9\-]+/[a-z0-9\-]+)"',
+    r'href="(?:https?://(?:www\.)?liveaboard\.com)?(/diving/' + DESTINATION + r'/[a-z0-9\-]+)"',
     re.IGNORECASE,
 )
-"""Boat detail links, absolute or relative.
+"""Boat detail links for the configured destination, absolute or relative.
 
-The first attempt anchored on a literal ``/diving/egypt/`` prefix and matched
-nothing across two live pages, so this accepts any two-segment ``/diving/``
-path and an optional absolute host.
+Scoped deliberately tightly. A previous version accepted any two-segment
+``/diving/`` path, and because the search page is a global template linking
+every destination the site sells — 138 Indonesia links, 74 Rhine river cruises
+— the crawler walked off into Antarctica. The page's own links are no guide to
+what the page is about.
 """
+
+NON_BOAT_SLUGS = frozenset(
+    {
+        "red-sea", "sharm-el-sheikh", "hurghada", "marsa-alam", "port-ghalib",
+        "safaga", "brothers-islands", "daedalus-reef", "elphinstone",
+        "st-johns", "fury-shoal", "ras-mohammed", "tiran", "thistlegorm",
+        "abu-nuhas", "liveaboards", "reviews", "deals",
+    }
+)
+"""Second-path segments under ``/diving/egypt/`` that are regions, dive sites or
+site furniture rather than vessels. ``/diving/egypt/red-sea`` matched the boat
+pattern in the last run and is not a boat."""
 
 
 class LiveaboardComAdapter(SourceAdapter):
@@ -76,62 +98,135 @@ class LiveaboardComAdapter(SourceAdapter):
     source_id = "liveaboard.com"
     host = HOST
 
-    def discover(self) -> Iterator[str]:
-        """Crawl the month searches, then each boat page they link to."""
-        seen: set[str] = set()
-        found_any = False
+    @staticmethod
+    def boat_links(html: str) -> set[str]:
+        """Vessel paths on a listing page, with regions and dive sites removed."""
+        found = set()
+        for match in BOAT_LINK.finditer(html):
+            path = match.group(1).lower()
+            if path.rsplit("/", 1)[-1] not in NON_BOAT_SLUGS:
+                found.add(path)
+        return found
 
-        for path in search_paths() + DESTINATION_PATHS:
+    def _listing_urls(self) -> Iterator[str]:
+        """Every result page of every month search, then the fallback listings.
+
+        Paging is walked rather than assumed: the loop stops as soon as a page
+        adds no boat the previous ones did not, so a month with one page costs
+        one extra request and a month with three is covered in full.
+        """
+        for base in search_paths():
+            per_month: set[str] = set()
+            for page in range(1, MAX_SEARCH_PAGES + 1):
+                url = f"https://{self.host}{base}" + (f"?page={page}" if page > 1 else "")
+                try:
+                    listing = self.fetcher.get(url)
+                except Exception as exc:  # noqa: BLE001 - a dead page must not end the run
+                    self.note(f"listing unavailable {url}: {exc}")
+                    break
+
+                links = self.boat_links(listing.body)
+                fresh = links - per_month
+                if page > 1 and not fresh:
+                    break
+                if not links:
+                    self.note(f"no boat links matched on {url}")
+                    break
+                per_month |= links
+                yield url
+            self.note(f"{base}: {len(per_month)} boats across up to {MAX_SEARCH_PAGES} pages")
+
+        for path in DESTINATION_PATHS:
             url = f"https://{self.host}{path}"
             try:
-                listing = self.fetcher.get(url)
-            except Exception as exc:  # noqa: BLE001 - a dead listing must not end the run
-                # Reported rather than swallowed: a silently skipped listing is
-                # indistinguishable from a site with nothing to sell.
+                self.fetcher.get(url)
+            except Exception as exc:  # noqa: BLE001
                 self.note(f"listing unavailable {url}: {exc}")
                 continue
             yield url
 
-            links = {match.group(1) for match in BOAT_LINK.finditer(listing.body)}
-            if not links:
-                self.note(f"no boat links matched on {url}")
-            for link in sorted(links):
-                boat_url = f"https://{self.host}{link}"
-                if boat_url not in seen:
-                    seen.add(boat_url)
-                    found_any = True
-                    if len(seen) > self.max_pages:
-                        self.note(f"stopped at {self.max_pages} boat pages; more were available")
-                        return
-                    yield boat_url
+    def discover(self) -> Iterator[str]:
+        """Crawl the month searches, then each boat page they link to."""
+        seen: set[str] = set()
 
-        if not found_any:
+        for listing_url in self._listing_urls():
+            yield listing_url
+            # Already snapshotted by the fetcher, so re-reading is free.
+            listing = self.fetcher.get(listing_url)
+            for link in sorted(self.boat_links(listing.body)):
+                boat_url = f"https://{self.host}{link}"
+                if boat_url in seen:
+                    continue
+                seen.add(boat_url)
+                if len(seen) > self.max_pages:
+                    self.note(f"stopped at {self.max_pages} boat pages; more were available")
+                    return
+                yield boat_url
+
+        if not seen:
             self.note("no boat pages were discovered from any listing")
 
     def parse(self, result: FetchResult) -> ScrapeOutput:
-        """Prefer structured data; fall back to markup only when there is none."""
+        """Read a boat page's departures from its structured data.
+
+        The departures are ``Event`` nodes, each with its own ``Offer`` — a live
+        page carried ten of each. The ``Product`` node describes the vessel and
+        typically holds only an ``AggregateOffer``, which is a "from" price and
+        no use for comparing what a specific sailing costs.
+        """
         output = ScrapeOutput()
-        products = jsonld.of_type(result.body, "Product", "TouristTrip", "Trip")
-        if not products:
+        slug = urlparse(result.url).path.rstrip("/").rsplit("/", 1)[-1]
+
+        events = jsonld.of_type(result.body, "Event", "TouristTrip", "Trip")
+        products = jsonld.of_type(result.body, "Product")
+
+        if not events and not products:
             raise ScrapeError(
-                f"no JSON-LD Product/Trip node in {result.url}; "
+                f"no JSON-LD Event or Product node in {result.url}; "
                 f"inspect the snapshot ({result.digest}) and add a markup parser"
             )
 
-        for node in products:
-            departure = self._departure_from(node, result)
+        if products:
+            product = products[0]
+            output.itineraries.append(
+                {
+                    "id": slug,
+                    "name": product.get("name"),
+                    "boat": product.get("name"),
+                    "summary": product.get("description"),
+                    "source_url": result.url,
+                    "provenance": self.provenance(result.url),
+                }
+            )
+
+        for index, event in enumerate(events):
+            departure = self._departure_from(event, result, slug, index)
             if departure:
                 output.departures.append(departure)
-        if not output.departures:
-            output.warnings.append(f"{result.url}: JSON-LD present but carried no priced offer")
+
+        if events and not output.departures:
+            output.warnings.append(
+                f"{result.url}: {len(events)} Event nodes but none carried a usable price"
+            )
+        elif not events:
+            output.warnings.append(f"{result.url}: Product node but no Event nodes")
         return output
 
-    def _departure_from(self, node: dict[str, Any], result: FetchResult) -> dict[str, Any] | None:
-        """Build a departure record from one structured-data node.
+    def _departure_from(
+        self, node: dict[str, Any], result: FetchResult, slug: str, index: int
+    ) -> dict[str, Any] | None:
+        """Build one departure from an ``Event`` node.
 
-        Returns ``None`` rather than guessing when the node carries no price:
-        an invented number on a price-transparency site would be self-defeating.
+        Returns ``None`` rather than guessing whenever a date or price is
+        missing. An invented number on a price-transparency site would be
+        self-defeating, and a departure without dates cannot be booked or
+        compared anyway.
         """
+        start = _iso_date(node.get("startDate"))
+        end = _iso_date(node.get("endDate"))
+        if not start or not end:
+            return None
+
         offer = jsonld.first_offer(node)
         if not offer:
             return None
@@ -139,10 +234,35 @@ class LiveaboardComAdapter(SourceAdapter):
         currency = offer.get("priceCurrency")
         if price is None or not currency:
             return None
+        try:
+            amount = float(str(price).replace(",", ""))
+        except ValueError:
+            return None
 
         return {
+            "id": f"{slug}-{start}-{index}",
+            "itinerary_id": slug,
             "name": node.get("name"),
-            "price": {"amount": float(price), "currency": str(currency).upper()},
+            "start": start,
+            "end": end,
+            "price": {"amount": amount, "currency": str(currency).upper()},
+            "availability": offer.get("availability"),
+            "booking_url": offer.get("url") or node.get("url"),
             "provenance": self.provenance(result.url),
-            "source_url": result.url,
         }
+
+
+def _iso_date(value: Any) -> str | None:
+    """Take the date part of a schema.org date or dateTime.
+
+    Accepts ``2027-05-01`` and ``2027-05-01T00:00:00+02:00`` alike, and refuses
+    anything that is not a plain ISO date once the time is stripped.
+    """
+    if not isinstance(value, str) or len(value) < 10:
+        return None
+    head = value[:10]
+    try:
+        date.fromisoformat(head)
+    except ValueError:
+        return None
+    return head

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -1,0 +1,134 @@
+"""Tests for link discovery, departure extraction and fetch caching.
+
+Each of these pins down something a live run got wrong.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from liveaboard.scrape.base import FetchResult, PoliteFetcher
+from liveaboard.scrape.liveaboard_com import LiveaboardComAdapter, _iso_date
+
+NOW = datetime(2026, 8, 27, tzinfo=timezone.utc)
+
+
+def result(body: str, url: str = "https://www.liveaboard.com/diving/egypt/a-boat") -> FetchResult:
+    return FetchResult(url=url, status=200, body=body, fetched_at=NOW)
+
+
+class TestBoatLinks(unittest.TestCase):
+    """The search page is a global template linking every destination sold."""
+
+    HTML = """
+      <a href="/diving/egypt/blue-horizon">boat</a>
+      <a href="https://www.liveaboard.com/diving/egypt/sea-serpent">boat</a>
+      <a href="/diving/egypt/red-sea">region</a>
+      <a href="/diving/indonesia/adelaar">other destination</a>
+      <a href="/diving/antarctica/hondius-antarctica-diving">other destination</a>
+      <a href="/river-cruise/rhine/amsterdam">not even diving</a>
+    """
+
+    def setUp(self):
+        self.found = LiveaboardComAdapter.boat_links(self.HTML)
+
+    def test_finds_egypt_boats_relative_and_absolute(self):
+        self.assertIn("/diving/egypt/blue-horizon", self.found)
+        self.assertIn("/diving/egypt/sea-serpent", self.found)
+
+    def test_excludes_other_destinations(self):
+        """A previous version crawled Antarctica off an Egypt search page."""
+        self.assertNotIn("/diving/antarctica/hondius-antarctica-diving", self.found)
+        self.assertNotIn("/diving/indonesia/adelaar", self.found)
+
+    def test_excludes_regions_and_dive_sites(self):
+        self.assertNotIn("/diving/egypt/red-sea", self.found)
+
+    def test_finds_exactly_the_two_boats(self):
+        self.assertEqual(len(self.found), 2)
+
+
+class TestIsoDate(unittest.TestCase):
+    def test_plain_date_passes_through(self):
+        self.assertEqual(_iso_date("2027-05-01"), "2027-05-01")
+
+    def test_datetime_is_truncated(self):
+        self.assertEqual(_iso_date("2027-05-01T09:30:00+02:00"), "2027-05-01")
+
+    def test_junk_is_refused(self):
+        for value in ("next Tuesday", "2027-13-45", "", None, 20270501):
+            self.assertIsNone(_iso_date(value), value)
+
+
+class TestDepartureExtraction(unittest.TestCase):
+    """Departures live in Event nodes, not in the Product's aggregate offer."""
+
+    HTML = """
+    <html><head>
+    <script type="application/ld+json">
+    {"@type":"Product","name":"MY Example","description":"A vessel.",
+     "offers":{"@type":"AggregateOffer","lowPrice":"900","priceCurrency":"USD"}}
+    </script>
+    <script type="application/ld+json">
+    {"@type":"Event","name":"Brothers & Daedalus","startDate":"2027-05-01T00:00:00",
+     "endDate":"2027-05-08","offers":{"@type":"Offer","price":"1,450",
+     "priceCurrency":"USD","availability":"InStock","url":"/BookingStep1?x=1"}}
+    </script>
+    <script type="application/ld+json">
+    {"@type":"Event","name":"No price","startDate":"2027-06-05","endDate":"2027-06-12"}
+    </script>
+    <script type="application/ld+json">
+    {"@type":"Event","name":"No dates",
+     "offers":{"@type":"Offer","price":"1200","priceCurrency":"USD"}}
+    </script>
+    </head><body></body></html>
+    """
+
+    def setUp(self):
+        adapter = LiveaboardComAdapter(PoliteFetcher(snapshot_dir="/tmp/unused"))
+        self.output = adapter.parse(result(self.HTML))
+
+    def test_only_the_complete_event_becomes_a_departure(self):
+        self.assertEqual(len(self.output.departures), 1)
+
+    def test_dates_and_price_are_read(self):
+        departure = self.output.departures[0]
+        self.assertEqual(departure["start"], "2027-05-01")
+        self.assertEqual(departure["end"], "2027-05-08")
+        self.assertEqual(departure["price"], {"amount": 1450.0, "currency": "USD"})
+
+    def test_price_keeps_its_quoted_currency(self):
+        """Conversion belongs in pricing.py, which records the rate it used."""
+        self.assertEqual(self.output.departures[0]["price"]["currency"], "USD")
+
+    def test_booking_url_is_carried(self):
+        self.assertEqual(self.output.departures[0]["booking_url"], "/BookingStep1?x=1")
+
+    def test_departure_is_tied_to_the_page_slug(self):
+        self.assertEqual(self.output.departures[0]["itinerary_id"], "a-boat")
+
+    def test_the_product_becomes_an_itinerary(self):
+        self.assertEqual(len(self.output.itineraries), 1)
+        self.assertEqual(self.output.itineraries[0]["name"], "MY Example")
+
+    def test_aggregate_offer_is_not_treated_as_a_price(self):
+        """A 'from' price is not what any specific sailing costs."""
+        prices = [d["price"]["amount"] for d in self.output.departures]
+        self.assertNotIn(900.0, prices)
+
+
+class TestFetchCache(unittest.TestCase):
+    def test_second_get_is_served_from_cache(self):
+        """Listing pages are read twice by design; paying twice is slow and rude."""
+        fetcher = PoliteFetcher(snapshot_dir="/tmp/unused")
+        stored = result("<html></html>", url="https://example.test/a")
+        fetcher._cache[stored.url] = stored
+
+        again = fetcher.get(stored.url)
+        self.assertTrue(again.from_cache)
+        self.assertEqual(again.body, stored.body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/probe_network.py
+++ b/tools/probe_network.py
@@ -38,6 +38,13 @@ PAGING_KEYS = ("page", "offset", "start", "limit", "per_page", "size", "cursor")
 
 PRICE_KEY = re.compile(r"price|cost|amount|fare|rate", re.I)
 
+BOAT_SLUG = re.compile(r'href="(?:https?://[^"/]+)?(/diving/egypt/[a-z0-9\-]+)"', re.I)
+
+
+def _boat_slugs(html: str) -> set[str]:
+    """Egypt boat paths in a page, used to tell one result page from another."""
+    return {m.group(1).lower() for m in BOAT_SLUG.finditer(html)}
+
 
 def shape(value: Any, depth: int = 0) -> str:
     """Summarise a JSON value's structure rather than dumping its content."""
@@ -156,12 +163,54 @@ def probe_one(browser: Any, url: str) -> None:
     html = page.content()
     print(f"  rendered size: {len(html) / 1024:.0f} KB")
 
-    # Does anything on the page look like a paginator?
-    paging = page.eval_on_selector_all(
-        "a[href*='page'], [class*='pagin'] a, [class*='Pagin'] a",
-        "els => els.map(e => e.getAttribute('href')).filter(Boolean).slice(0, 12)",
+    # Paging is the immediate blocker, so look for it several ways rather than
+    # trusting one selector: an anchor, a button, a rel=next hint, or the word
+    # "page" anywhere in the rendered markup.
+    print("\n  -- pagination --")
+
+    anchors = page.eval_on_selector_all(
+        "a[href*='page'], a[href*='Page'], [class*='pagin'] a, [class*='Pagin'] a, "
+        "nav a, [aria-label*='age'] , link[rel='next'], a[rel='next']",
+        """els => els.map(e => ({
+             tag: e.tagName,
+             href: e.getAttribute('href'),
+             rel: e.getAttribute('rel'),
+             label: (e.getAttribute('aria-label') || e.textContent || '').trim().slice(0, 30)
+           })).filter(x => x.href || x.label).slice(0, 25)""",
     )
-    print(f"  pagination links: {paging if paging else 'none found in DOM'}")
+    for item in anchors:
+        print(f"    {item['tag']:6} {str(item['href'])[:70]:72} {item['label']}")
+    if not anchors:
+        print("    no paginator anchors matched")
+
+    buttons = page.eval_on_selector_all(
+        "button, [role='button']",
+        """els => els.map(e => (e.textContent || '').trim())
+             .filter(t => /next|more|page|\\d+$/i.test(t) && t.length < 24).slice(0, 15)""",
+    )
+    if buttons:
+        print(f"    button labels: {buttons}")
+
+    for pattern in (r"[?&]page=\d+", r"[?&]p=\d+", r"/page/\d+", r'"totalPages"\s*:\s*\d+',
+                    r'"pageCount"\s*:\s*\d+', r"showing\s+\d+\s*[-–]\s*\d+\s+of\s+\d+"):
+        hits = re.findall(pattern, html, re.I)
+        if hits:
+            unique = sorted(set(hits))[:8]
+            print(f"    markup matches {pattern}: {unique}")
+
+    # Does ?page=2 actually return different boats, or silently repeat page 1?
+    first_ids = _boat_slugs(html)
+    print(f"    boat links on this page: {len(first_ids)}")
+    try:
+        page.goto(f"{url}?page=2", wait_until="domcontentloaded", timeout=45000)
+        second = _boat_slugs(page.content())
+        overlap = len(first_ids & second)
+        print(
+            f"    ?page=2 -> {len(second)} boat links, {overlap} shared with page 1"
+            + ("  (SAME PAGE — paging is not ?page=)" if second and overlap == len(second) else "")
+        )
+    except Exception as exc:  # noqa: BLE001 - the probe must not die on one navigation
+        print(f"    ?page=2 navigation failed: {exc}")
 
     if not calls:
         print("  no XHR/fetch calls — the listing is server-rendered, parse the HTML")


### PR DESCRIPTION
Acts on [probe run 33083638748](https://github.com/PaludaNCode/Liveaboard/actions/runs/33083638748).

## What the probe established

The four month searches return 200 with titles like **"79 Egypt liveaboards, August 2027"**, carry **no JSON-LD**, quote in **USD**, and are **entirely server-rendered**: every XHR is analytics plus `GetWishList` (a wishlist, not results), `support-wizard/load-view-component` and `breakpoint/logging`. **There is no search API to query** — the listing must be read from markup.

## Link scoping — the crawler went to Antarctica

The widened boat-link pattern matched any two-segment `/diving/` path. A search page links every destination the site sells:

```
138 /diving/indonesia/*   118 /diving/egypt/*   74 /river-cruise/rhine/*
```

…so it fetched three *Antarctic* boat pages. Only the `max_pages` cap stopped it. Now scoped to the configured destination, with region and dive-site slugs excluded — `/diving/egypt/red-sea` matched the boat shape and is not a boat.

## Departures — the accidental find

The Antarctic page it wandered onto revealed the real data model:

```
json-ld: Organization×21, Event×10, PlayAction×10, Place×10, Offer×10, Product×1
```

**`Event×10` with `Offer×10` is ten departures with ten prices.** The parser only read `Product` nodes, whose offer is an `AggregateOffer` — a "from" price, useless for comparing a specific sailing. It now parses `Event` nodes for dates, price and booking link, keeping `Product` as the vessel record.

Prices keep their quoted currency; conversion stays in `pricing.py`, which records the rate and date it used.

## Paging

Walks `?page=N` per month, stopping as soon as a page adds no new boat — so a one-page month costs one extra request and August's three are covered. The probe now hunts paging four ways (anchors, buttons, `rel=next`, markup patterns) and checks whether `?page=2` returns *different* boats or silently repeats page one.

## Fetching

Responses are cached for the life of a run. Listing pages are read twice by design — once to find links, once to parse — and at a five-second crawl delay paying twice is both slow and rude.

81 tests, up from 66. New coverage pins the Antarctica bug, the aggregate-offer trap, and date/price refusal when either is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_