### PR TITLE
Drop pagination: the server sends every result at once

### DIFF
--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -49,12 +49,12 @@ def search_paths() -> tuple[str, ...]:
     )
 
 
-MAX_SEARCH_PAGES = 5
-"""Result pages to walk per month.
-
-August is known to run to three. Five leaves headroom without crawling
-forever; the walk stops early as soon as a page yields no new boats.
-"""
+# Paging deliberately not implemented. A live probe showed ?page=2 returning
+# byte-identical content to page 1, "pageCount":0 in the markup, and 100 boat
+# links already present on the first response against a title of "79 Egypt
+# liveaboards". The site's "Next" button pages the rendered view in the
+# browser; the server sends every result at once. One fetch per month is the
+# whole month.
 
 DESTINATION_PATHS = (
     "/diving/egypt",
@@ -81,15 +81,23 @@ what the page is about.
 
 NON_BOAT_SLUGS = frozenset(
     {
-        "red-sea", "sharm-el-sheikh", "hurghada", "marsa-alam", "port-ghalib",
-        "safaga", "brothers-islands", "daedalus-reef", "elphinstone",
-        "st-johns", "fury-shoal", "ras-mohammed", "tiran", "thistlegorm",
-        "abu-nuhas", "liveaboards", "reviews", "deals",
+        # Regions and dive sites seen in the search page's own destination nav.
+        "red-sea", "thistlegorm", "ras-mohammed", "the-brothers",
+        "straits-of-tiran", "abu-nuhas", "daedalus", "elphinstone", "st-johns",
+        "abu-dabab", "brothers-islands", "daedalus-reef", "fury-shoal", "tiran",
+        "sharm-el-sheikh", "hurghada", "marsa-alam", "port-ghalib", "safaga",
+        # Site furniture.
+        "liveaboards", "reviews", "deals",
     }
 )
-"""Second-path segments under ``/diving/egypt/`` that are regions, dive sites or
-site furniture rather than vessels. ``/diving/egypt/red-sea`` matched the boat
-pattern in the last run and is not a boat."""
+"""Segments under ``/diving/egypt/`` that are places, not vessels.
+
+The search page links roughly twenty of these from its destination nav, and
+they take the same URL shape as a boat. Skipping them by name saves a wasted
+fetch each; the real guarantee is downstream, where a page with no ``Event``
+nodes yields no departures and says so. This list is an optimisation, not a
+correctness boundary — an unknown dive site costs one request, not a bad price.
+"""
 
 
 class LiveaboardComAdapter(SourceAdapter):
@@ -109,40 +117,22 @@ class LiveaboardComAdapter(SourceAdapter):
         return found
 
     def _listing_urls(self) -> Iterator[str]:
-        """Every result page of every month search, then the fallback listings.
-
-        Paging is walked rather than assumed: the loop stops as soon as a page
-        adds no boat the previous ones did not, so a month with one page costs
-        one extra request and a month with three is covered in full.
-        """
-        for base in search_paths():
-            per_month: set[str] = set()
-            for page in range(1, MAX_SEARCH_PAGES + 1):
-                url = f"https://{self.host}{base}" + (f"?page={page}" if page > 1 else "")
-                try:
-                    listing = self.fetcher.get(url)
-                except Exception as exc:  # noqa: BLE001 - a dead page must not end the run
-                    self.note(f"listing unavailable {url}: {exc}")
-                    break
-
-                links = self.boat_links(listing.body)
-                fresh = links - per_month
-                if page > 1 and not fresh:
-                    break
-                if not links:
-                    self.note(f"no boat links matched on {url}")
-                    break
-                per_month |= links
-                yield url
-            self.note(f"{base}: {len(per_month)} boats across up to {MAX_SEARCH_PAGES} pages")
-
-        for path in DESTINATION_PATHS:
+        """One search page per season month, then the fallback listings."""
+        for path in search_paths() + DESTINATION_PATHS:
             url = f"https://{self.host}{path}"
             try:
-                self.fetcher.get(url)
-            except Exception as exc:  # noqa: BLE001
+                listing = self.fetcher.get(url)
+            except Exception as exc:  # noqa: BLE001 - a dead listing must not end the run
+                # Reported rather than swallowed: a silently skipped listing is
+                # indistinguishable from a site with nothing to sell.
                 self.note(f"listing unavailable {url}: {exc}")
                 continue
+
+            count = len(self.boat_links(listing.body))
+            if not count:
+                self.note(f"no boat links matched on {url}")
+            else:
+                self.note(f"{path}: {count} boats")
             yield url
 
     def discover(self) -> Iterator[str]:

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -48,6 +48,22 @@ class TestBoatLinks(unittest.TestCase):
     def test_finds_exactly_the_two_boats(self):
         self.assertEqual(len(self.found), 2)
 
+    def test_rejects_the_dive_sites_the_search_page_actually_links(self):
+        """Taken verbatim from a live search page's destination nav."""
+        sites = [
+            "red-sea", "thistlegorm", "ras-mohammed", "the-brothers",
+            "straits-of-tiran", "abu-nuhas", "daedalus", "elphinstone",
+            "st-johns", "abu-dabab",
+        ]
+        html = "".join(f'<a href="/diving/egypt/{slug}">x</a>' for slug in sites)
+        self.assertEqual(LiveaboardComAdapter.boat_links(html), set())
+
+    def test_keeps_the_boats_the_same_page_links(self):
+        html = "".join(
+            f'<a href="/diving/egypt/{slug}">x</a>' for slug in ("alia-soul", "all-star-ghani")
+        )
+        self.assertEqual(len(LiveaboardComAdapter.boat_links(html)), 2)
+
 
 class TestIsoDate(unittest.TestCase):
     def test_plain_date_passes_through(self):


### PR DESCRIPTION
[Probe run 33084333520](https://github.com/PaludaNCode/Liveaboard/actions/runs/33084333520) settled the three-page question — and confirmed the parser works.

## The parser produces real data

```
3 itineraries, 20 departures

/diving/egypt/alia-soul      Event×10, Offer×10  →  10 departures
/diving/egypt/all-star-ghani Event×10, Offer×10  →  10 departures
/diving/egypt/abu-dabab      Product, AggregateOffer, no Events → 0
```

Two real vessels, twenty real departures, exactly the `Event`/`Offer` model predicted.

## Pagination does not exist server-side

```
button labels: ['May 2027', 'Show all 22', 'Next', 'Show all 22']
markup matches "pageCount": ['"pageCount":0']
boat links on this page: 100
?page=2 -> 100 boat links, 100 shared with page 1  (SAME PAGE)
```

`?page=2` returns content identical to page 1, and page 1 already holds 100 boat-shaped links against a title of *"79 Egypt liveaboards, May 2027"*. The **Next** button pages the rendered view in the browser; the server never pages. One fetch per month is the whole month, so the `?page=N` walk is **removed** rather than left as dead code that reads like caution.

## The 100 vs 79 gap

The difference is the destination nav, which links ~20 dive sites in the same URL shape as a vessel — `the-brothers`, `straits-of-tiran`, `daedalus`, `abu-dabab` and the rest, taken verbatim from the live page. Those are now skipped by name.

That list is an **optimisation, not a correctness boundary**: it saves one request each. The real guarantee is downstream — a page with no `Event` nodes yields no departures and says so, which is exactly what `abu-dabab` did when it was crawled as a boat. An unknown dive site costs a request, never a bad price.

83 tests, up from 81; the new ones pin the real slugs the live page links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_