### PR TITLE
Add promote, and stop reporting unknown fees as no fees

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -45,13 +45,26 @@ jobs:
       - name: Run tests
         run: PYTHONPATH=src python3 -m unittest discover -s tests
 
-      - name: Scrape sources
+      # padi.com is parked: both its entry paths 404 and it contributes
+      # requirements, not prices. Scraping only what works keeps a failing
+      # source from muddying a good run.
+      - name: Scrape liveaboard.com
         id: scrape
         continue-on-error: true
         run: |
           PYTHONPATH=src python3 -m liveaboard.cli scrape \
+            --source liveaboard.com \
             --out data/candidate.json \
             --snapshots data/snapshots
+
+      - name: Promote the candidate
+        id: promote
+        if: steps.scrape.outcome == 'success'
+        continue-on-error: true
+        run: |
+          PYTHONPATH=src python3 -m liveaboard.cli promote \
+            --candidate data/candidate.json \
+            --out data/egypt-2027.json
 
       - name: Report a blocked or empty scrape
         if: steps.scrape.outcome == 'failure'
@@ -69,11 +82,22 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+      - name: Pick the dataset to publish
+        id: dataset
+        run: |
+          # Prefer promoted, scraped data; fall back to the seed so a failed
+          # scrape publishes yesterday's site rather than nothing.
+          if [ -f data/egypt-2027.json ]; then
+            echo "path=data/egypt-2027.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=data/seed/egypt-2027.json" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate the dataset
-        run: PYTHONPATH=src python3 -m liveaboard.cli check
+        run: PYTHONPATH=src python3 -m liveaboard.cli check --data ${{ steps.dataset.outputs.path }}
 
       - name: Build the site
-        run: PYTHONPATH=src python3 -m liveaboard.cli build
+        run: PYTHONPATH=src python3 -m liveaboard.cli build --data ${{ steps.dataset.outputs.path }}
 
       - name: Commit changes
         run: |

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 from .classify import classify
 from .dataset import Dataset, DatasetError
-from .pricing import compute, transparency_score
+from .pricing import compute, resolve_fees, transparency_score
+from .promote import promote
 from .render import render
 from .scrape.base import FetchBlocked, PoliteFetcher, ScrapeOutput
 from .scrape.liveaboard_com import LiveaboardComAdapter
@@ -57,27 +58,42 @@ def cmd_check(args: argparse.Namespace) -> int:
     print(f"  sources: {', '.join(sorted(k.value for k in dataset.source_kinds))}")
     print()
 
-    rows: list[tuple[str, float, float, float, float]] = []
+    rows: list[tuple[str, float, float, float | None, float | None]] = []
+    unknown = 0
     for key, itinerary in dataset.itineraries.items():
         departures = [d for d in dataset.departures if d.itinerary_id == key]
         if not departures:
             continue
         first = departures[0]
         breakdown = compute(itinerary, first, dataset.fx)
+        # Same rule as the rendered page: no fee lines means nobody has looked,
+        # not that the advertised price is the whole bill.
+        known = bool(resolve_fees(itinerary, first))
+        if not known:
+            unknown += 1
         rows.append(
             (
                 itinerary.name,
                 float(breakdown.base.rounded),
                 float(breakdown.total.rounded),
-                breakdown.markup_pct,
-                transparency_score(itinerary, first, dataset.fx) * 100,
+                breakdown.markup_pct if known else None,
+                transparency_score(itinerary, first, dataset.fx) * 100 if known else None,
             )
         )
 
-    width = max(len(r[0]) for r in rows) if rows else 20
+    width = min(max((len(r[0]) for r in rows), default=20), 44)
     print(f"  {'itinerary'.ljust(width)}  {'advertised':>11} {'true cost':>10} {'markup':>8} {'honesty':>8}")
-    for name, base, total, markup, honesty in sorted(rows, key=lambda r: -r[3]):
-        print(f"  {name.ljust(width)}  {base:>11,.0f} {total:>10,.0f} {markup:>7.0f}% {honesty:>7.0f}%")
+    for name, base, total, markup, honesty in sorted(rows, key=lambda r: -(r[3] or -1)):
+        if markup is None:
+            print(f"  {name[:width].ljust(width)}  {base:>11,.0f} {'unknown':>10} {'—':>8} {'—':>8}")
+        else:
+            print(
+                f"  {name[:width].ljust(width)}  {base:>11,.0f} {total:>10,.0f} "
+                f"{markup:>7.0f}% {honesty:>7.0f}%"
+            )
+
+    if unknown:
+        print(f"\n  {unknown} of {len(rows)} itineraries have no fee data captured yet")
 
     print()
     for key, itinerary in dataset.itineraries.items():
@@ -154,6 +170,47 @@ def cmd_scrape(args: argparse.Namespace) -> int:
     return 1 if blocked else 0
 
 
+def cmd_promote(args: argparse.Namespace) -> int:
+    """Turn a scrape candidate into a dataset, refusing to publish a worse one.
+
+    The size check is the guard that matters: a source redesign that halves the
+    departure count should stop the pipeline, not quietly shrink the site.
+    """
+    candidate = json.loads(Path(args.candidate).read_text(encoding="utf-8"))
+    season = (date.fromisoformat(args.season_start), date.fromisoformat(args.season_end))
+    payload = promote(candidate, season=season)
+
+    incoming = len(payload["departures"])
+    if incoming == 0:
+        print("candidate contains no departures in the season window", file=sys.stderr)
+        return 1
+
+    target = Path(args.out)
+    if target.exists() and not args.force:
+        existing = json.loads(target.read_text(encoding="utf-8"))
+        previous = len(existing.get("departures", []))
+        floor = int(previous * args.min_ratio)
+        if previous and incoming < floor:
+            print(
+                f"refusing to promote: {incoming} departures against {previous} already "
+                f"published (floor {floor}). Re-run, or pass --force if the drop is real.",
+                file=sys.stderr,
+            )
+            return 1
+
+    Dataset.from_dict(payload)  # validates, raising DatasetError on a bad shape
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(
+        f"promoted {target}: {incoming} departures, "
+        f"{len(payload['itineraries'])} itineraries, {len(payload['boats'])} boats"
+    )
+    for skipped in payload.get("promotion_skipped", [])[:10]:
+        print(f"  ! {skipped}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="liveaboard", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -186,6 +243,20 @@ def main(argv: list[str] | None = None) -> int:
         help="print each page's structure: JSON-LD types, link shapes, price hints",
     )
     scrape.set_defaults(func=cmd_scrape)
+
+    promote_cmd = sub.add_parser("promote", help="turn a scrape candidate into the dataset")
+    promote_cmd.add_argument("--candidate", default=Path("data/candidate.json"), type=Path)
+    promote_cmd.add_argument("--out", default=Path("data/egypt-2027.json"), type=Path)
+    promote_cmd.add_argument("--season-start", default="2027-05-01")
+    promote_cmd.add_argument("--season-end", default="2027-08-31")
+    promote_cmd.add_argument(
+        "--min-ratio",
+        type=float,
+        default=0.6,
+        help="refuse to publish below this fraction of the current departure count",
+    )
+    promote_cmd.add_argument("--force", action="store_true", help="publish despite a large drop")
+    promote_cmd.set_defaults(func=cmd_promote)
 
     args = parser.parse_args(argv)
     return int(args.func(args))

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -1,0 +1,187 @@
+"""Turn a candidate scrape into a dataset the site can render.
+
+Promotion is deliberately a separate step from scraping. A source site changing
+its markup should degrade into "yesterday's prices plus a warning", never into
+a published page full of blanks, and that only holds if something has to
+actively decide the new data is good enough.
+
+What the scrape gives us is boats, dates and prices. What it does not give us
+is fees — and that gap is the whole reason this module is careful. An itinerary
+with no fee lines is not an itinerary with no fees; it is one we have not
+looked at yet. Those two must never render the same way, or a site built to
+expose hidden costs would be hiding them itself.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import date
+from typing import Any
+
+UNKNOWN_OPERATOR = {
+    "id": "unknown-operator",
+    "name": "Operator not captured",
+}
+"""liveaboard.com is an agency listing: it names the vessel, not who runs it.
+
+Inventing an operator would be worse than admitting we do not know one.
+"""
+
+MIN_NIGHTS = 1
+MAX_NIGHTS = 30
+"""Sanity bounds. A departure outside these is a parsing error, not a cruise."""
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", value.lower())).strip("-")
+
+
+def _nights(start: str, end: str) -> int | None:
+    try:
+        delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
+    except ValueError:
+        return None
+    return delta if MIN_NIGHTS <= delta <= MAX_NIGHTS else None
+
+
+def promote(
+    candidate: dict[str, Any],
+    *,
+    season: tuple[date, date] | None = None,
+    fx: dict[str, Any] | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Build a dataset payload from a scrape candidate.
+
+    Departures are grouped into itineraries by (vessel, trip name): the same
+    boat sells several routes through a season, and lumping them together would
+    average away the difference between a wreck week and a shark week.
+    """
+    scraped_boats = {i.get("id"): i for i in candidate.get("itineraries", []) if i.get("id")}
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    skipped: list[str] = []
+
+    for departure in candidate.get("departures", []):
+        slug = departure.get("boat_slug")
+        if not slug:
+            skipped.append(f"{departure.get('id')}: no boat")
+            continue
+        nights = _nights(departure["start"], departure["end"])
+        if nights is None:
+            skipped.append(f"{departure.get('id')}: implausible dates")
+            continue
+        if season and not (season[0] <= date.fromisoformat(departure["start"]) <= season[1]):
+            continue
+        name = (departure.get("name") or "Unnamed itinerary").strip()
+        grouped[(slug, name)].append({**departure, "nights": nights})
+
+    boats: dict[str, dict[str, Any]] = {}
+    itineraries: list[dict[str, Any]] = []
+    departures: list[dict[str, Any]] = []
+
+    for (slug, name), group in sorted(grouped.items()):
+        source = scraped_boats.get(slug, {})
+        boat_name = source.get("boat") or source.get("name") or slug.replace("-", " ").title()
+        boats.setdefault(
+            slug,
+            {"id": slug, "name": boat_name, "operator_id": UNKNOWN_OPERATOR["id"]},
+        )
+
+        itinerary_id = f"{slug}--{slugify(name)}"[:96]
+        nights = _most_common(d["nights"] for d in group)
+        ports = [d.get("location") for d in group if d.get("location")]
+
+        itineraries.append(
+            {
+                "id": itinerary_id,
+                "name": name,
+                "operator_id": UNKNOWN_OPERATOR["id"],
+                "boat_id": slug,
+                "nights": nights,
+                "dives": 0,
+                "port_from": ports[0] if ports else "Unknown",
+                "port_to": ports[0] if ports else "Unknown",
+                # Left empty on purpose. Route and theme are derived from dive
+                # sites, which this source does not publish; the classifier
+                # falls back to the trip name, which usually carries them.
+                "dive_sites": _sites_from_name(name),
+                "summary": source.get("summary"),
+                "source_url": source.get("source_url"),
+                # No fee data was scraped. The renderer must show this as
+                # unknown rather than as zero.
+                "fees": [],
+            }
+        )
+
+        for item in group:
+            departures.append(
+                {
+                    "id": item["id"],
+                    "itinerary_id": itinerary_id,
+                    "start": item["start"],
+                    "end": item["end"],
+                    "price": item["price"],
+                    "booking_url": item.get("booking_url"),
+                    "provenance": item["provenance"],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "generated": candidate.get("scraped_at") or date.today().isoformat(),
+        "default_currency": "EUR",
+        "notes": notes
+        or (
+            "Prices scraped from liveaboard.com. Fees are not yet captured, so "
+            "true cost is shown as unknown rather than as the advertised price."
+        ),
+        "fx": fx or _default_fx(),
+        "operators": [UNKNOWN_OPERATOR],
+        "boats": sorted(boats.values(), key=lambda b: b["name"]),
+        "itineraries": itineraries,
+        "departures": departures,
+    }
+    if skipped:
+        payload["promotion_skipped"] = skipped
+    return payload
+
+
+def _most_common(values) -> int:
+    counts: dict[int, int] = defaultdict(int)
+    for value in values:
+        counts[value] += 1
+    return max(counts.items(), key=lambda kv: (kv[1], -kv[0]))[0]
+
+
+SITE_HINTS = (
+    "brothers", "daedalus", "elphinstone", "thistlegorm", "abu nuhas",
+    "rocky island", "zabargad", "st johns", "st john's", "fury shoal",
+    "sataya", "ras mohammed", "tiran", "salem express", "rosalie moller",
+    "gubal", "abu dabab", "samadai", "habili ali", "dangerous reef",
+    "gota kebir", "sha'ab", "shaab", "elphinstone reef", "big brother",
+    "little brother", "numidia", "aida", "carnatic", "giannis d",
+)
+"""Dive-site names that routinely appear in itinerary titles.
+
+liveaboard.com does not publish a per-trip site list, but operators name their
+routes after the sites — "Brothers, Daedalus & Elphinstone" says exactly where
+it goes. Pulling the names back out of the title lets the existing classifier
+work unchanged instead of leaving every scraped trip unclassified.
+"""
+
+
+def _sites_from_name(name: str) -> list[str]:
+    """Recover dive-site names from an itinerary title."""
+    lowered = name.lower()
+    return [hint for hint in SITE_HINTS if hint in lowered]
+
+
+def _default_fx() -> dict[str, Any]:
+    return {
+        "display_currency": "EUR",
+        "as_of": date.today().isoformat(),
+        "source": "placeholder — replace with a real rate source",
+        "rates": {"USD": 0.92, "GBP": 1.17, "EGP": 0.019},
+    }

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -20,7 +20,7 @@ from typing import Any
 from .classify import classify, themes_in_season
 from .dataset import Dataset
 from .money import DISPLAY_CURRENCY
-from .pricing import DEFAULT_TOGGLES, compute, transparency_score
+from .pricing import DEFAULT_TOGGLES, compute, resolve_fees, transparency_score
 from .taxonomy import (
     DIVER_LEVEL_LABELS,
     DIVER_LEVEL_ORDER,
@@ -84,9 +84,16 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
         breakdown = compute(itinerary, departure, dataset.fx)
         themes = classifications[itinerary.id].themes
 
+        # An itinerary with no fee lines is not one with no fees; it is one
+        # nobody has looked at yet. Reporting a true cost equal to the
+        # advertised price, and a perfect honesty score, would make this site
+        # commit exactly the omission it exists to expose.
+        fees_known = bool(resolve_fees(itinerary, departure))
+
         departures.append(
             {
                 "id": departure.id,
+                "fees_known": fees_known,
                 "itinerary_id": itinerary.id,
                 "boat_id": itinerary.boat_id,
                 "start": departure.start.isoformat(),
@@ -97,7 +104,11 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
                 "booking_url": departure.booking_url,
                 "base": float(breakdown.base.rounded),
                 "lines": [line.as_dict() for line in breakdown.lines],
-                "transparency": round(transparency_score(itinerary, departure, dataset.fx), 4),
+                "transparency": (
+                    round(transparency_score(itinerary, departure, dataset.fx), 4)
+                    if fees_known
+                    else None
+                ),
                 "peak_themes": [t.value for t in themes_in_season(themes, departure.start.month)],
                 "verified": departure.price_provenance.is_verified,
             }

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -231,15 +231,37 @@ class LiveaboardComAdapter(SourceAdapter):
 
         return {
             "id": f"{slug}-{start}-{index}",
-            "itinerary_id": slug,
+            "boat_slug": slug,
             "name": node.get("name"),
             "start": start,
             "end": end,
             "price": {"amount": amount, "currency": str(currency).upper()},
             "availability": offer.get("availability"),
             "booking_url": offer.get("url") or node.get("url"),
+            "location": _place_name(node.get("location")),
             "provenance": self.provenance(result.url),
         }
+
+
+def _place_name(location: Any) -> str | None:
+    """The departure port, from an Event's ``location``.
+
+    Each Event carries a Place with a PostalAddress. The town is the useful
+    part — Hurghada, Port Ghalib, Marsa Alam — because it is what a diver books
+    flights against.
+    """
+    if isinstance(location, list):
+        location = location[0] if location else None
+    if not isinstance(location, dict):
+        return None
+    address = location.get("address")
+    if isinstance(address, dict):
+        for key in ("addressLocality", "addressRegion", "streetAddress"):
+            value = address.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    name = location.get("name")
+    return name.strip() if isinstance(name, str) and name.strip() else None
 
 
 def _iso_date(value: Any) -> str | None:

--- a/templates/app.js
+++ b/templates/app.js
@@ -87,7 +87,13 @@
     per_night: function (a, b) { return metricsFor(a).perNight - metricsFor(b).perNight; },
     base: function (a, b) { return a.base - b.base; },
     markup: function (a, b) { return metricsFor(b).markup - metricsFor(a).markup; },
-    transparency: function (a, b) { return b.transparency - a.transparency; }
+    /* Departures with no fee data sort last rather than winning on a score
+       they were never given. */
+    transparency: function (a, b) {
+      var x = a.transparency === null ? -1 : a.transparency;
+      var y = b.transparency === null ? -1 : b.transparency;
+      return y - x;
+    }
   };
 
   function groupsFor(departures) {
@@ -168,6 +174,17 @@
 
     block.appendChild(el("div", "per-night", euro.format(m.perNight) + " per night"));
 
+    /* Without fee data there is no true cost to report. Saying "no extras to
+       add" would claim we checked, and claiming a perfect honesty score would
+       reward an operator for our own missing homework. */
+    if (!dep.fees_known) {
+      var unknown = el("div", "advertised");
+      unknown.appendChild(el("span", "unknown", "advertised price only"));
+      block.appendChild(unknown);
+      block.appendChild(el("div", "honesty-unknown", "Extra fees not yet captured"));
+      return block;
+    }
+
     var advertised = el("div", "advertised");
     if (m.surcharge > 0.5) {
       advertised.appendChild(el("span", "was", "advertised " + euro.format(dep.base)));
@@ -239,11 +256,22 @@
     });
 
     var totalRow = el("tr", "total");
-    totalRow.appendChild(el("td", null, "True cost"));
+    totalRow.appendChild(el("td", null, dep.fees_known ? "True cost" : "Advertised price"));
     totalRow.appendChild(el("td"));
     totalRow.appendChild(el("td"));
     totalRow.appendChild(el("td", "num", euro.format(m.total)));
     body.appendChild(totalRow);
+
+    if (!dep.fees_known) {
+      var caveat = el("tr");
+      var cell = el("td", "fee-note",
+        "Marine park fees, port dues, fuel, nitrox and gratuities are not " +
+        "included above because they have not been captured for this trip yet. " +
+        "On comparable trips they add 30–60%.");
+      cell.colSpan = 4;
+      caveat.appendChild(cell);
+      body.appendChild(caveat);
+    }
 
     table.appendChild(body);
     return table;
@@ -313,7 +341,9 @@
 
     var isOpen = state.open.has(dep.id);
     var button = el("button", "disclose",
-      isOpen ? "Hide the breakdown" : "Where does " + euro.format(m.total) + " come from?");
+      isOpen ? "Hide the breakdown"
+             : dep.fees_known ? "Where does " + euro.format(m.total) + " come from?"
+                              : "What is missing from " + euro.format(m.total) + "?");
     button.type = "button";
     button.setAttribute("aria-expanded", isOpen ? "true" : "false");
     button.addEventListener("click", function () {
@@ -407,13 +437,26 @@
     var totals = matching.map(function (d) { return metricsFor(d).total; });
     var cheapest = Math.min.apply(null, totals);
     var dearest = Math.max.apply(null, totals);
+    var priced = matching.filter(function (d) { return d.fees_known; }).length;
+
+    /* Only call it a true cost when it is one. With no fee data the range is
+       just the advertised prices, and labelling it otherwise would repeat the
+       claim this site exists to challenge. */
+    var label = priced === matching.length ? " · true cost "
+              : priced === 0 ? " · advertised "
+              : " · advertised or true cost ";
+
     summary.innerHTML = "";
     summary.appendChild(document.createTextNode("Showing "));
     summary.appendChild(el("b", null, String(matching.length)));
     summary.appendChild(document.createTextNode(
-      " of " + DATA.departures.length + " departures · true cost " +
+      " of " + DATA.departures.length + " departures" + label +
       euro.format(cheapest) + " to " + euro.format(dearest)
     ));
+    if (priced < matching.length) {
+      summary.appendChild(el("span", "summary-caveat",
+        " · fees not yet captured for " + (matching.length - priced)));
+    }
 
     groupsFor(matching).forEach(function (group) {
       var heading = el("h2", "group-heading");

--- a/templates/style.css
+++ b/templates/style.css
@@ -268,6 +268,19 @@ select {
 .markup { font-weight: 650; color: var(--bad); }
 .markup.none { color: var(--good); }
 
+.advertised .unknown { color: var(--text-faint); font-style: italic; }
+
+.honesty-unknown {
+  margin-top: 8px;
+  padding: 3px 8px;
+  display: inline-block;
+  font-size: .76rem;
+  color: var(--warn);
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: var(--radius-sm);
+}
+
 .honesty { margin-top: 9px; }
 .honesty-label { font-size: .72rem; color: var(--text-faint); letter-spacing: .05em; text-transform: uppercase; }
 .honesty-bar { height: 5px; margin-top: 3px; border-radius: 3px; background: var(--surface-2); overflow: hidden; }
@@ -349,3 +362,5 @@ table.fees tr.base-row td { background: var(--surface); }
   .price-block { text-align: left; min-width: 0; }
   .honesty-bar { max-width: 200px; }
 }
+
+.summary-caveat { color: var(--warn); }

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,179 @@
+"""Tests for turning a scrape candidate into a publishable dataset."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from liveaboard.dataset import Dataset
+from liveaboard.promote import promote, slugify
+from liveaboard.render import build_payload
+
+SEASON = (date(2027, 5, 1), date(2027, 8, 31))
+
+PROV = {"kind": "scraped", "source_id": "liveaboard.com", "retrieved": "2026-08-27"}
+
+
+def departure(
+    boat: str = "alia-soul",
+    name: str = "Brothers, Daedalus & Elphinstone",
+    start: str = "2027-05-01",
+    end: str = "2027-05-08",
+    price: float = 1450.0,
+    currency: str = "USD",
+    **extra,
+) -> dict:
+    return {
+        "id": f"{boat}-{start}",
+        "boat_slug": boat,
+        "name": name,
+        "start": start,
+        "end": end,
+        "price": {"amount": price, "currency": currency},
+        "provenance": PROV,
+        **extra,
+    }
+
+
+def candidate(departures, itineraries=None) -> dict:
+    return {
+        "scraped_at": "2026-08-27",
+        "itineraries": itineraries
+        or [{"id": "alia-soul", "name": "Alia Soul", "boat": "Alia Soul"}],
+        "departures": departures,
+    }
+
+
+class TestGrouping(unittest.TestCase):
+    def test_same_boat_different_trips_stay_separate(self):
+        """A boat sells several routes; averaging them hides the difference."""
+        payload = promote(
+            candidate(
+                [
+                    departure(name="Brothers, Daedalus & Elphinstone"),
+                    departure(name="Northern Wrecks", start="2027-05-15", end="2027-05-22"),
+                ]
+            ),
+            season=SEASON,
+        )
+        self.assertEqual(len(payload["itineraries"]), 2)
+        self.assertEqual(len(payload["boats"]), 1)
+
+    def test_same_trip_across_dates_is_one_itinerary(self):
+        payload = promote(
+            candidate(
+                [
+                    departure(start="2027-05-01", end="2027-05-08"),
+                    departure(start="2027-06-05", end="2027-06-12"),
+                ]
+            ),
+            season=SEASON,
+        )
+        self.assertEqual(len(payload["itineraries"]), 1)
+        self.assertEqual(len(payload["departures"]), 2)
+
+    def test_nights_are_derived_from_the_dates(self):
+        payload = promote(candidate([departure()]), season=SEASON)
+        self.assertEqual(payload["itineraries"][0]["nights"], 7)
+
+    def test_port_comes_from_the_event_location(self):
+        payload = promote(
+            candidate([departure(location="Port Ghalib")]), season=SEASON
+        )
+        self.assertEqual(payload["itineraries"][0]["port_from"], "Port Ghalib")
+
+
+class TestRejection(unittest.TestCase):
+    def test_departures_outside_the_season_are_dropped(self):
+        payload = promote(
+            candidate([departure(start="2027-11-06", end="2027-11-13")]), season=SEASON
+        )
+        self.assertEqual(payload["departures"], [])
+
+    def test_implausible_dates_are_skipped_and_reported(self):
+        """A 400-night cruise is a parsing error, not a product."""
+        payload = promote(
+            candidate([departure(start="2027-05-01", end="2028-06-01")]), season=SEASON
+        )
+        self.assertEqual(payload["departures"], [])
+        self.assertTrue(payload["promotion_skipped"])
+
+    def test_a_departure_with_no_boat_is_skipped(self):
+        broken = departure()
+        del broken["boat_slug"]
+        payload = promote(candidate([broken]), season=SEASON)
+        self.assertEqual(payload["departures"], [])
+
+
+class TestFeesAreUnknownNotZero(unittest.TestCase):
+    """The distinction this whole project turns on."""
+
+    def setUp(self):
+        payload = promote(candidate([departure()]), season=SEASON)
+        self.dataset = Dataset.from_dict(payload)
+        self.rendered = build_payload(self.dataset)["departures"][0]
+
+    def test_scraped_itineraries_carry_no_fee_lines(self):
+        self.assertEqual(self.dataset.itineraries[
+            list(self.dataset.itineraries)[0]
+        ].fees, [])
+
+    def test_the_page_is_told_the_fees_are_unknown(self):
+        self.assertFalse(self.rendered["fees_known"])
+
+    def test_no_honesty_score_is_invented(self):
+        """A perfect score here would reward the operator for our missing work."""
+        self.assertIsNone(self.rendered["transparency"])
+
+
+class TestClassificationSurvivesTheMissingSiteList(unittest.TestCase):
+    def test_dive_sites_are_recovered_from_the_trip_name(self):
+        """The source publishes no site list, but names routes after sites."""
+        payload = promote(candidate([departure()]), season=SEASON)
+        sites = payload["itineraries"][0]["dive_sites"]
+        self.assertIn("brothers", sites)
+        self.assertIn("daedalus", sites)
+
+    def test_a_scraped_trip_still_gets_a_route(self):
+        dataset = Dataset.from_dict(promote(candidate([departure()]), season=SEASON))
+        classification = next(iter(dataset.classifications().values()))
+        self.assertIsNotNone(classification.route)
+
+    def test_an_unrecognisable_name_yields_no_sites(self):
+        payload = promote(
+            candidate([departure(name="Summer Special Week")]), season=SEASON
+        )
+        self.assertEqual(payload["itineraries"][0]["dive_sites"], [])
+
+
+class TestPayloadValidity(unittest.TestCase):
+    def test_promoted_payload_passes_dataset_validation(self):
+        payload = promote(
+            candidate(
+                [
+                    departure(),
+                    departure(boat="all-star-ghani", start="2027-07-03", end="2027-07-10"),
+                ],
+                itineraries=[
+                    {"id": "alia-soul", "boat": "Alia Soul"},
+                    {"id": "all-star-ghani", "boat": "All Star Ghani"},
+                ],
+            ),
+            season=SEASON,
+        )
+        dataset = Dataset.from_dict(payload)
+        self.assertEqual(len(dataset.departures), 2)
+        self.assertEqual(len(dataset.boats), 2)
+
+    def test_prices_keep_their_scraped_currency(self):
+        payload = promote(candidate([departure(currency="USD")]), season=SEASON)
+        self.assertEqual(payload["departures"][0]["price"]["currency"], "USD")
+
+
+class TestSlugify(unittest.TestCase):
+    def test_punctuation_collapses(self):
+        self.assertEqual(slugify("Brothers, Daedalus & Elphinstone"), "brothers-daedalus-elphinstone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -121,8 +121,9 @@ class TestDepartureExtraction(unittest.TestCase):
     def test_booking_url_is_carried(self):
         self.assertEqual(self.output.departures[0]["booking_url"], "/BookingStep1?x=1")
 
-    def test_departure_is_tied_to_the_page_slug(self):
-        self.assertEqual(self.output.departures[0]["itinerary_id"], "a-boat")
+    def test_departure_is_tied_to_the_vessel_page(self):
+        """The itinerary is formed later, by grouping departures at promote time."""
+        self.assertEqual(self.output.departures[0]["boat_slug"], "a-boat")
 
     def test_the_product_becomes_an_itinerary(self):
         self.assertEqual(len(self.output.itineraries), 1)

--- a/tools/probe_network.py
+++ b/tools/probe_network.py
@@ -99,6 +99,57 @@ def describe_json(payload: Any) -> list[str]:
     return lines
 
 
+FEE_WORDS = re.compile(
+    r"not\s+included|excluded|extra(?:s)?\b|surcharge|marine\s*park|park\s*fee|"
+    r"port\s*fee|harbou?r|fuel|nitrox|visa|gratuit|tip(?:s|ping)\b|"
+    r"equipment\s*rental|rental\s*equipment|mandatory|payable\s+(?:on|at)",
+    re.I,
+)
+"""The vocabulary operators use for the costs they leave out of the headline."""
+
+
+def hunt_fees(page: Any, html: str) -> None:
+    """Locate the fee disclosure on a page, in markup or in embedded JSON.
+
+    This is the missing half of the dataset: prices scrape cleanly, fees do
+    not, and until they do the site can only report an advertised number and
+    admit it does not know the rest.
+    """
+    print("\n  -- fee disclosure --")
+
+    blocks = page.eval_on_selector_all(
+        "li, td, dd, p, span, div",
+        """els => els
+             .filter(e => e.children.length === 0)
+             .map(e => (e.textContent || '').replace(/\\s+/g, ' ').trim())
+             .filter(t => t.length > 3 && t.length < 160)""",
+    )
+    hits, seen = [], set()
+    for text in blocks:
+        if FEE_WORDS.search(text) and text.lower() not in seen:
+            seen.add(text.lower())
+            hits.append(text)
+    if hits:
+        print(f"    {len(hits)} fee-ish text nodes; first 30:")
+        for text in hits[:30]:
+            print(f"      · {text}")
+    else:
+        print("    no fee wording found in rendered text")
+
+    # Embedded state often carries the fees as data long before the DOM shows
+    # them, and data beats scraping prose off a layout.
+    for script in re.findall(r"<script[^>]*>(.*?)</script>", html, re.S)[:60]:
+        if not FEE_WORDS.search(script) or len(script) > 400_000:
+            continue
+        keys = sorted(set(re.findall(r'"([A-Za-z_][A-Za-z0-9_]{2,40})"\s*:', script)))
+        fee_keys = [k for k in keys if FEE_WORDS.search(k) or PRICE_KEY.search(k)]
+        if fee_keys:
+            print(f"    embedded JSON keys of interest: {fee_keys[:30]}")
+            for match in re.finditer(r'"([^"]{0,40}(?:ee|harge|ax|ip)s?)"\s*:\s*([0-9.]+)', script):
+                print(f"      {match.group(1)} = {match.group(2)}")
+            break
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", action="append", default=None)
@@ -211,6 +262,8 @@ def probe_one(browser: Any, url: str) -> None:
         )
     except Exception as exc:  # noqa: BLE001 - the probe must not die on one navigation
         print(f"    ?page=2 navigation failed: {exc}")
+
+    hunt_fees(page, html)
 
     if not calls:
         print("  no XHR/fetch calls — the listing is server-rendered, parse the HTML")


### PR DESCRIPTION
Builds `promote` (#4), and fixes a bug that building it exposed.

## The bug promotion would have shipped

Scraped data gives boats, dates and prices — **but no fees**. With no fee lines the engine returned a true cost equal to the advertised price and a **100% honesty score**. A site built to expose omitted costs would have been committing the omission itself, and rewarding operators for our missing homework.

An itinerary with no fee lines is not one with no fees. It is one nobody has looked at yet. Those must never render alike, and the distinction now runs through **every** surface:

| Surface | Before | After |
| --- | --- | --- |
| Card | `€1,409` · "no extras to add" · Honesty 100% | `€1,409` · "advertised price only" · **Extra fees not yet captured** |
| Breakdown | "True cost €1,409" | "Advertised price €1,409" + what's missing |
| Summary | "true cost €1,139 to €1,882" | "advertised €1,139 to €1,882 · fees not yet captured for 54" |
| Honesty sort | unscored trips win at 100% | unscored trips sort last |
| `cli check` | `0% markup, 100% honesty` | `unknown  —  —` |

## promote

- **Groups by vessel *and* trip name.** One boat sells several routes; lumping them together would average away the difference between a wreck week and a shark week.
- **Derives nights** from the dates, and the **port** from each `Event`'s `location`.
- **Recovers dive sites from the trip name.** The source publishes no site list, but operators name routes after where they go — "Brothers, Daedalus & Elphinstone" says it outright. This keeps the existing classifier working on scraped data instead of leaving every trip unclassified.
- **Refuses to publish a shrunken dataset**: under 60% of the live departure count stops the pipeline rather than quietly halving the site. `--force` when the drop is real.
- **Names the operator "not captured"** rather than inventing one — this source lists vessels, not the companies running them.

## Workflow

Scrapes liveaboard.com only, promotes, and publishes the promoted dataset when there is one — falling back to the seed so a failed scrape ships yesterday's site rather than nothing. **padi.com is parked** per instruction: both entry paths 404 and it contributes requirements, not prices.

The probe can now hunt fee disclosure in rendered text and embedded JSON — the half of the dataset still missing.

99 tests, up from 83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_