### PR TITLE
Raise the page cap to cover all 79 Egypt vessels

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4

--- a/src/liveaboard/scrape/base.py
+++ b/src/liveaboard/scrape/base.py
@@ -225,7 +225,11 @@ class SourceAdapter(ABC):
     #: Cap on detail pages per run. At a five second crawl delay an uncapped
     #: listing can outlast the CI job timeout, and a truncated scrape that says
     #: so beats one that is killed halfway through.
-    max_pages: int = 60
+    #:
+    #: Egypt lists 79 vessels, so 60 would have silently dropped a quarter of
+    #: the season. 120 covers it with headroom; at five seconds apiece that is
+    #: about ten minutes, well inside the job's thirty.
+    max_pages: int = 120
 
     def __init__(self, fetcher: PoliteFetcher) -> None:
         self.fetcher = fetcher


### PR DESCRIPTION
The detail-page cap was 60 against a listing of **79 vessels**, so the first full run would have silently dropped a quarter of the season. The cap exists to stop a crawl outlasting the CI job, not to sample it.

At five seconds a page, 120 pages is about ten minutes; the job timeout goes from 30 to 45 minutes to leave room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_