### PR TITLE
Scrape the fee disclosure, and keep ranges and unpriced extras honest

### DIFF
--- a/src/liveaboard/models.py
+++ b/src/liveaboard/models.py
@@ -80,7 +80,22 @@ class FeeItem:
 
     code: FeeCode
     tier: FeeTier
-    amount: Money
+    amount: Money | None
+    """The stated amount, or the low end of a stated range.
+
+    ``None`` means the operator listed the extra without a figure — "Rental
+    Gear" with no price beside it. That is a real cost of unknown size, and
+    treating it as zero would be a straightforward falsehood.
+    """
+
+    amount_max: Money | None = None
+    """The high end, when the page quotes a range like "€35-100".
+
+    Ranges are common and wide: park fees quoted at 35 to 100 euro are a 65 euro
+    spread on a supposedly fixed charge. Keeping only the low end would
+    understate the bill, which is the failure this project exists to correct.
+    """
+
     basis: FeeBasis = FeeBasis.PER_TRIP
     included: bool = False
     provenance: Provenance | None = None
@@ -95,25 +110,50 @@ class FeeItem:
         """The site toggle that governs this fee, if any."""
         return TOGGLEABLE.get(self.code)
 
-    def for_trip(self, nights: int, dives: int) -> Money:
-        """Normalise the quoted basis to a single per-person trip total."""
+    @property
+    def has_price(self) -> bool:
+        return self.amount is not None
+
+    @property
+    def is_range(self) -> bool:
+        return self.amount_max is not None and self.amount_max != self.amount
+
+    def _scale(self, money: Money, nights: int, dives: int) -> Money:
         if self.basis is FeeBasis.PER_TRIP:
-            return self.amount
+            return money
         if self.basis is FeeBasis.PER_NIGHT:
-            return self.amount * nights
+            return money * nights
         if self.basis in (FeeBasis.PER_DAY, FeeBasis.PER_PERSON_PER_DAY):
-            return self.amount * (nights + 1)
+            return money * (nights + 1)
         if self.basis is FeeBasis.PER_DIVE:
-            return self.amount * dives
+            return money * dives
         raise ValueError(f"unhandled fee basis {self.basis}")
+
+    def span_for_trip(self, nights: int, dives: int) -> tuple[Money | None, Money | None]:
+        """Normalise the quoted basis to a per-person trip low and high."""
+        if self.amount is None:
+            return None, None
+        low = self._scale(self.amount, nights, dives)
+        high = self._scale(self.amount_max, nights, dives) if self.amount_max else low
+        return low, high
+
+    def for_trip(self, nights: int, dives: int) -> Money:
+        """The low end, normalised. Raises when no price was stated."""
+        low, _ = self.span_for_trip(nights, dives)
+        if low is None:
+            raise ValueError(f"{self.code.value} has no stated price")
+        return low
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any], default_currency: str) -> FeeItem:
         prov = payload.get("provenance")
+        raw = payload.get("amount")
+        raw_max = payload.get("amount_max")
         return cls(
             code=FeeCode(payload["code"]),
             tier=FeeTier(payload["tier"]),
-            amount=Money.parse(payload["amount"], default_currency),
+            amount=Money.parse(raw, default_currency) if raw is not None else None,
+            amount_max=Money.parse(raw_max, default_currency) if raw_max is not None else None,
             basis=FeeBasis(payload.get("basis", FeeBasis.PER_TRIP.value)),
             included=bool(payload.get("included", False)),
             provenance=Provenance.from_dict(prov) if prov else None,

--- a/src/liveaboard/pricing.py
+++ b/src/liveaboard/pricing.py
@@ -62,30 +62,55 @@ class BreakdownLine:
     code: FeeCode
     label: str
     tier: FeeTier
-    quoted: Money
-    display: Money
+    quoted: Money | None
+    display: Money | None
     included: bool
     counted: bool
     toggle: str | None
     provenance: Provenance | None
     note: str | None
     fx_rate: FxRate | None
+    display_max: Money | None = None
+    """High end of a quoted range, in display currency. ``None`` when fixed."""
+
+    @property
+    def has_price(self) -> bool:
+        return self.display is not None
+
+    @property
+    def is_range(self) -> bool:
+        return self.display_max is not None and self.display_max != self.display
 
     @property
     def charged(self) -> Money:
-        """What this line adds to the total: zero when bundled or switched off."""
-        if self.included or not self.counted:
-            return zero(self.display.currency)
+        """What this line adds to the total at the low end.
+
+        An unpriced line adds nothing to the arithmetic but is *not* free; the
+        breakdown flags it separately so the page can say so.
+        """
+        if self.included or not self.counted or self.display is None:
+            return zero(DISPLAY_CURRENCY)
         return self.display
+
+    @property
+    def charged_max(self) -> Money:
+        """What this line adds at the high end of its stated range."""
+        if self.included or not self.counted or self.display is None:
+            return zero(DISPLAY_CURRENCY)
+        return self.display_max or self.display
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "code": self.code.value,
             "label": self.label,
             "tier": self.tier.value,
-            "quoted": self.quoted.as_dict(),
-            "display": self.display.as_dict(),
+            "quoted": self.quoted.as_dict() if self.quoted else None,
+            "display": self.display.as_dict() if self.display else None,
+            "display_max": self.display_max.as_dict() if self.is_range else None,
             "charged": float(self.charged.rounded),
+            "charged_max": float(self.charged_max.rounded),
+            "has_price": self.has_price,
+            "is_range": self.is_range,
             "included": self.included,
             "counted": self.counted,
             "toggle": self.toggle,
@@ -121,6 +146,31 @@ class Breakdown:
         return total
 
     @property
+    def total_max(self) -> Money:
+        """The total at the top of every quoted range."""
+        total = zero(DISPLAY_CURRENCY)
+        for line in self.lines:
+            total = total + line.charged_max
+        return total
+
+    @property
+    def is_range(self) -> bool:
+        return self.total_max.amount != self.total.amount
+
+    @property
+    def unpriced(self) -> list[BreakdownLine]:
+        """Counted lines the operator listed without a figure.
+
+        These sit outside the arithmetic entirely: they are known costs of
+        unknown size, so the honest total is "at least this much, plus these".
+        """
+        return [
+            line
+            for line in self.lines
+            if line.counted and not line.included and not line.has_price
+        ]
+
+    @property
     def surcharge(self) -> Money:
         """Everything on top of the advertised price."""
         return Money(self.total.amount - self.base.amount, self.total.currency)
@@ -150,6 +200,9 @@ class Breakdown:
             "departure_id": self.departure_id,
             "base": float(self.base.rounded),
             "total": float(self.total.rounded),
+            "total_max": float(self.total_max.rounded),
+            "is_range": self.is_range,
+            "unpriced": [line.code.value for line in self.unpriced],
             "surcharge": float(self.surcharge.rounded),
             "per_night": float(self.per_night.rounded),
             "markup_pct": round(self.markup_pct, 1),
@@ -213,15 +266,22 @@ def compute(
     )
 
     for fee in _sorted_fees(resolve_fees(itinerary, departure)):
-        quoted = fee.for_trip(itinerary.nights, itinerary.dives)
-        display, rate = fx.to_display(quoted)
+        low, high = fee.span_for_trip(itinerary.nights, itinerary.dives)
+
+        display = display_max = rate = None
+        if low is not None:
+            display, rate = fx.to_display(low)
+            if high is not None and high != low:
+                display_max, _ = fx.to_display(high)
+
         breakdown.lines.append(
             BreakdownLine(
                 code=fee.code,
                 label=fee.label,
                 tier=fee.tier,
-                quoted=quoted,
+                quoted=low,
                 display=display,
+                display_max=display_max,
                 included=fee.included,
                 counted=_is_counted(fee, active),
                 toggle=fee.toggle,

--- a/src/liveaboard/scrape/fees.py
+++ b/src/liveaboard/scrape/fees.py
@@ -1,0 +1,226 @@
+"""Parse liveaboard.com's "Required Extras" and "Optional Extras" blocks.
+
+The disclosure looks like this, verbatim from a vessel page:
+
+    Required Extras: Environment Tax (€45), Fuel Surcharge (€60-70 / trip),
+    National Park Fees (€35-100 / trip), Port Fees (€35).
+
+    Optional Extras: Gratuities (€80), Nitrox (€30 / trip),
+    Nitrox Course (€250 / item), Private Dive Guide (€500 / trip),
+    Rental Gear, Scuba Diving Courses (€300-350),
+    Laundry / Pressing Services (€5 / item).
+
+Three details drive the whole design here:
+
+* **Amounts are ranges as often as not.** "€35-100" for park fees is a 65 euro
+  spread on a supposedly fixed cost. Collapsing it to the low end would
+  understate the bill, which is the exact failure this project exists to
+  correct, so both ends are kept and the total is reported as a range.
+
+* **Some extras carry no price at all** — "Rental Gear" is listed and left
+  blank. That is a third state, distinct from zero and from absent, and it has
+  to survive to the page.
+
+* **The site's own Required/Optional split is authoritative** for whether a
+  cost is escapable, but not for how it should be counted. Gratuities are filed
+  under Optional here and are nevertheless paid by nearly everyone.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ..taxonomy import FEE_LABELS, FeeBasis, FeeCode, FeeTier
+
+BLOCK = re.compile(
+    r"(Required|Optional)\s+Extras\s*:\s*(.+?)(?=(?:Required|Optional)\s+Extras\s*:|$)",
+    re.I | re.S,
+)
+
+ENTRY = re.compile(
+    r"""
+    (?P<label>[^,()]+?)                      # "National Park Fees"
+    \s*
+    (?:\(                                    # optional bracketed amount
+        \s*(?P<currency>[€$£])?\s*
+        (?P<low>\d[\d.,]*)
+        (?:\s*[-–]\s*(?P<high>\d[\d.,]*))?   # "60-70"
+        \s*(?:/\s*(?P<basis>trip|item|day|night|dive|person))?
+        [^)]*
+    \))?
+    \s*(?:,|\.|$)
+    """,
+    re.I | re.X,
+)
+
+CURRENCIES = {"€": "EUR", "$": "USD", "£": "GBP"}
+
+BASES = {
+    "trip": FeeBasis.PER_TRIP,
+    "item": FeeBasis.PER_TRIP,  # an "item" is one purchase on one trip
+    "day": FeeBasis.PER_DAY,
+    "night": FeeBasis.PER_NIGHT,
+    "dive": FeeBasis.PER_DIVE,
+    "person": FeeBasis.PER_TRIP,
+}
+
+# Matched longest-first so "Nitrox Course" never resolves as "Nitrox".
+LABEL_CODES: tuple[tuple[str, FeeCode], ...] = (
+    ("national park", FeeCode.MARINE_PARK),
+    ("marine park", FeeCode.MARINE_PARK),
+    ("park fee", FeeCode.MARINE_PARK),
+    ("environment tax", FeeCode.ENVIRONMENT_TAX),
+    ("environmental tax", FeeCode.ENVIRONMENT_TAX),
+    ("fuel surcharge", FeeCode.FUEL_SURCHARGE),
+    ("fuel", FeeCode.FUEL_SURCHARGE),
+    ("port fee", FeeCode.PORT_FEES),
+    ("harbour", FeeCode.PORT_FEES),
+    ("nitrox course", FeeCode.COURSE),
+    ("scuba diving course", FeeCode.COURSE),
+    ("diving course", FeeCode.COURSE),
+    ("course", FeeCode.COURSE),
+    ("nitrox", FeeCode.NITROX),
+    ("private dive guide", FeeCode.PRIVATE_GUIDE),
+    ("dive guide", FeeCode.PRIVATE_GUIDE),
+    ("rental gear", FeeCode.GEAR_RENTAL),
+    ("gear rental", FeeCode.GEAR_RENTAL),
+    ("equipment rental", FeeCode.GEAR_RENTAL),
+    ("rental equipment", FeeCode.GEAR_RENTAL),
+    ("gratuit", FeeCode.GRATUITIES),
+    ("tip", FeeCode.GRATUITIES),
+    ("laundry", FeeCode.LAUNDRY),
+    ("pressing", FeeCode.LAUNDRY),
+    ("visa", FeeCode.VISA),
+    ("insurance", FeeCode.DIVE_INSURANCE),
+    ("transfer", FeeCode.AIRPORT_TRANSFER),
+    ("single supplement", FeeCode.SINGLE_SUPPLEMENT),
+    ("vat", FeeCode.TAX_VAT),
+)
+
+# Optional-block codes that are nevertheless paid by nearly everyone, or that
+# the site's own toggles govern. The block a fee appears in decides whether it
+# is escapable; this decides how it is counted.
+CUSTOMARY_CODES = frozenset({FeeCode.GRATUITIES})
+TOGGLED_CODES = frozenset(
+    {
+        FeeCode.NITROX,
+        FeeCode.GEAR_RENTAL,
+        FeeCode.DIVE_INSURANCE,
+        FeeCode.AIRPORT_TRANSFER,
+    }
+)
+
+NOISE = re.compile(r"^\s*(and|or|etc|extras?|none|n/?a)\s*$", re.I)
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedFee:
+    """One extra as the page states it, before it becomes a :class:`FeeItem`."""
+
+    code: FeeCode
+    label: str
+    tier: FeeTier
+    low: float | None
+    high: float | None
+    currency: str
+    basis: FeeBasis
+
+    @property
+    def is_range(self) -> bool:
+        return self.high is not None and self.high != self.low
+
+    @property
+    def has_price(self) -> bool:
+        return self.low is not None
+
+
+def classify_label(label: str) -> FeeCode | None:
+    lowered = label.lower()
+    for needle, code in LABEL_CODES:
+        if needle in lowered:
+            return code
+    return None
+
+
+def _tier_for(code: FeeCode, required: bool) -> FeeTier:
+    if required:
+        return FeeTier.MANDATORY
+    if code in CUSTOMARY_CODES:
+        return FeeTier.CUSTOMARY
+    if code in TOGGLED_CODES:
+        return FeeTier.CONDITIONAL
+    return FeeTier.OPTIONAL
+
+
+def _number(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    cleaned = raw.replace(",", "").rstrip(".")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
+    """Extract every stated extra from a vessel page's disclosure text."""
+    found: list[ParsedFee] = []
+    seen: set[FeeCode] = set()
+
+    for required_word, body in BLOCK.findall(text):
+        required = required_word.lower() == "required"
+        for match in ENTRY.finditer(body):
+            label = " ".join(match.group("label").split())
+            if not label or NOISE.match(label):
+                continue
+            code = classify_label(label)
+            if code is None or code in seen:
+                continue
+            seen.add(code)
+
+            low = _number(match.group("low"))
+            high = _number(match.group("high"))
+            symbol = match.group("currency")
+            basis = BASES.get((match.group("basis") or "").lower(), FeeBasis.PER_TRIP)
+
+            found.append(
+                ParsedFee(
+                    code=code,
+                    label=label,
+                    tier=_tier_for(code, required),
+                    low=low,
+                    high=high if high is not None else low,
+                    currency=CURRENCIES.get(symbol or "", default_currency),
+                    basis=basis,
+                )
+            )
+    return found
+
+
+def to_fee_dicts(fees: list[ParsedFee], provenance: dict) -> list[dict]:
+    """Render parsed extras into the dataset's fee shape."""
+    out = []
+    for fee in fees:
+        entry: dict = {
+            "code": fee.code.value,
+            "tier": fee.tier.value,
+            "basis": fee.basis.value,
+            "included": False,
+            "provenance": provenance,
+        }
+        if fee.has_price:
+            entry["amount"] = {"amount": fee.low, "currency": fee.currency}
+            if fee.is_range:
+                entry["amount_max"] = {"amount": fee.high, "currency": fee.currency}
+                entry["note"] = f'Operator quotes "{fee.label}" as a range'
+            elif fee.label.lower() != FEE_LABELS.get(fee.code, "").lower():
+                # Keep the operator's own wording only when it says something
+                # our label does not; echoing it back is noise.
+                entry["note"] = fee.label
+        else:
+            # Listed with no figure. Never treated as free.
+            entry["amount"] = None
+            entry["note"] = f"{fee.label}: listed with no price"
+        out.append(entry)
+    return out

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 from .base import FetchResult, ScrapeError, ScrapeOutput, SourceAdapter
 from . import jsonld
+from .fees import parse_extras, to_fee_dicts
 
 HOST = "www.liveaboard.com"
 
@@ -178,6 +179,10 @@ class LiveaboardComAdapter(SourceAdapter):
 
         if products:
             product = products[0]
+            # Fees are a property of the vessel, not the sailing: the same
+            # extras apply whichever month you book. So they are read once per
+            # boat page and attached to every itinerary it yields.
+            extras = parse_extras(_page_text(result.body))
             output.itineraries.append(
                 {
                     "id": slug,
@@ -186,8 +191,11 @@ class LiveaboardComAdapter(SourceAdapter):
                     "summary": product.get("description"),
                     "source_url": result.url,
                     "provenance": self.provenance(result.url),
+                    "fees": to_fee_dicts(extras, self.provenance(result.url)),
                 }
             )
+            if not extras:
+                output.warnings.append(f"{result.url}: no Required/Optional Extras block found")
 
         for index, event in enumerate(events):
             departure = self._departure_from(event, result, slug, index)
@@ -241,6 +249,36 @@ class LiveaboardComAdapter(SourceAdapter):
             "location": _place_name(node.get("location")),
             "provenance": self.provenance(result.url),
         }
+
+
+SCRIPT_OR_STYLE = re.compile(r"<(script|style)\b[^>]*>.*?</\1>", re.I | re.S)
+BLOCK_END = re.compile(r"</(li|p|td|tr|div|h[1-6]|ul|ol|dd|dt)\s*>|<br\s*/?>", re.I)
+TAG = re.compile(r"<[^>]+>")
+
+
+def _page_text(html: str) -> str:
+    """Flatten markup to readable text.
+
+    The extras block is read from text rather than from selectors on purpose.
+    A probe that looked only at leaf elements missed it entirely, because
+    "Environment Tax (€45)" is split across an anchor and a span — the labels
+    and their amounts live in different nodes. Flattening puts them back
+    together and survives a redesign that moves them around again.
+    """
+    without_code = SCRIPT_OR_STYLE.sub(" ", html)
+    # Block boundaries become commas before the tags go. The extras are usually
+    # list items, and flattening them without a separator runs "Port Fees (€35)"
+    # straight into the next entry, destroying exactly the boundaries the parser
+    # needs. Prose renders the same list comma-separated anyway.
+    delimited = BLOCK_END.sub(", ", without_code)
+    text = TAG.sub(" ", delimited)
+    text = (
+        text.replace("&euro;", "€")
+        .replace("&pound;", "£")
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+    )
+    return re.sub(r"\s+", " ", text)
 
 
 def _place_name(location: Any) -> str | None:

--- a/src/liveaboard/taxonomy.py
+++ b/src/liveaboard/taxonomy.py
@@ -63,6 +63,7 @@ class FeeCode(str, Enum):
     FUEL_SURCHARGE = "fuel_surcharge"
     VISA = "visa"
     TAX_VAT = "tax_vat"
+    ENVIRONMENT_TAX = "environment_tax"
 
     NITROX = "nitrox"
     GEAR_RENTAL = "gear_rental"
@@ -77,6 +78,7 @@ class FeeCode(str, Enum):
     COURSE = "course"
     TANK_15L = "tank_15l"
     ALCOHOL = "alcohol"
+    LAUNDRY = "laundry"
 
 
 TOGGLEABLE: dict[FeeCode, str] = {
@@ -96,6 +98,7 @@ FEE_LABELS: dict[FeeCode, str] = {
     FeeCode.FUEL_SURCHARGE: "Fuel surcharge",
     FeeCode.VISA: "Egypt visa on arrival",
     FeeCode.TAX_VAT: "VAT / local tax",
+    FeeCode.ENVIRONMENT_TAX: "Environment tax",
     FeeCode.NITROX: "Nitrox",
     FeeCode.GEAR_RENTAL: "Equipment rental",
     FeeCode.DIVE_INSURANCE: "Dive insurance",
@@ -107,6 +110,7 @@ FEE_LABELS: dict[FeeCode, str] = {
     FeeCode.COURSE: "Course",
     FeeCode.TANK_15L: "15 L tank",
     FeeCode.ALCOHOL: "Alcoholic drinks",
+    FeeCode.LAUNDRY: "Laundry & pressing",
 }
 
 

--- a/templates/app.js
+++ b/templates/app.js
@@ -37,26 +37,45 @@
 
   /* ---------- pricing ---------- */
 
-  function lineCharged(line) {
-    if (line.included || line.tier === "optional") return 0;
-    if (line.toggle) return state.toggles[line.toggle] ? line.display.amount : 0;
-    return DEFAULT_ON_TIERS[line.tier] ? line.display.amount : 0;
+  /* Whether a line counts at all, independent of what it costs. A line with no
+     stated price still counts — it just cannot be added up. */
+  function lineCounts(line) {
+    if (line.included || line.tier === "optional") return false;
+    if (line.toggle) return !!state.toggles[line.toggle];
+    return !!DEFAULT_ON_TIERS[line.tier];
   }
 
-  function totalFor(dep) {
-    var sum = 0;
-    for (var i = 0; i < dep.lines.length; i++) sum += lineCharged(dep.lines[i]);
-    return sum;
+  function lineCharged(line, high) {
+    if (!lineCounts(line) || !line.has_price) return 0;
+    var top = high && line.display_max ? line.display_max.amount : line.display.amount;
+    return top;
   }
 
   function metricsFor(dep) {
-    var total = totalFor(dep);
+    var low = 0, high = 0, unpriced = [];
+    for (var i = 0; i < dep.lines.length; i++) {
+      var line = dep.lines[i];
+      low += lineCharged(line, false);
+      high += lineCharged(line, true);
+      if (lineCounts(line) && !line.has_price) unpriced.push(line.label);
+    }
     return {
-      total: total,
-      perNight: dep.nights > 0 ? total / dep.nights : total,
-      surcharge: total - dep.base,
-      markup: dep.base > 0 ? (total - dep.base) / dep.base * 100 : 0
+      total: low,
+      totalMax: high,
+      isRange: high > low + 0.5,
+      unpriced: unpriced,
+      perNight: dep.nights > 0 ? low / dep.nights : low,
+      surcharge: low - dep.base,
+      markup: dep.base > 0 ? (low - dep.base) / dep.base * 100 : 0
     };
+  }
+
+  /* "€1,757" when fixed, "€1,757–1,832" when the operator quoted a range.
+     Collapsing a range to one number would be the site's own hidden cost. */
+  function formatSpan(m) {
+    var low = Math.round(m.total).toLocaleString("en-IE");
+    if (!m.isRange) return low;
+    return low + "–" + Math.round(m.totalMax).toLocaleString("en-IE");
   }
 
   /* ---------- filtering ---------- */
@@ -169,10 +188,15 @@
 
     var cost = el("div", "true-cost");
     cost.appendChild(el("span", "cur", "€"));
-    cost.appendChild(document.createTextNode(Math.round(m.total).toLocaleString("en-IE")));
+    cost.appendChild(document.createTextNode(formatSpan(m)));
     block.appendChild(cost);
 
     block.appendChild(el("div", "per-night", euro.format(m.perNight) + " per night"));
+
+    if (m.unpriced.length) {
+      block.appendChild(el("div", "plus-unpriced",
+        "plus " + m.unpriced.join(", ").toLowerCase() + " at an unstated price"));
+    }
 
     /* Without fee data there is no true cost to report. Saying "no extras to
        add" would claim we checked, and claiming a perfect honesty score would
@@ -220,9 +244,9 @@
 
     var body = el("tbody");
     dep.lines.forEach(function (line) {
-      var charged = lineCharged(line);
+      var charged = lineCharged(line, false);
       var isBase = line.code === "base_fare";
-      var counted = isBase || charged > 0;
+      var counted = isBase || lineCounts(line);
       var row = el("tr", (counted ? "" : "off") + (isBase ? " base-row" : ""));
 
       var nameCell = el("td");
@@ -239,13 +263,27 @@
       if (!isBase) tierCell.appendChild(el("span", "tier " + line.tier, line.tier));
       row.appendChild(tierCell);
 
-      row.appendChild(el("td", "num", euro.format(line.display.amount)));
+      var amountCell = el("td", "num");
+      if (!line.has_price) {
+        amountCell.appendChild(el("span", "pill-off", "not stated"));
+      } else if (line.is_range) {
+        amountCell.appendChild(document.createTextNode(
+          euro.format(line.display.amount) + "–" + euro.format(line.display_max.amount)));
+      } else {
+        amountCell.appendChild(document.createTextNode(euro.format(line.display.amount)));
+      }
+      row.appendChild(amountCell);
 
       var statusCell = el("td", "num");
       if (line.included) {
         statusCell.appendChild(el("span", "pill-included", "in the fare"));
+      } else if (counted && !line.has_price) {
+        statusCell.appendChild(el("span", "pill-unpriced", "payable, amount unknown"));
       } else if (counted) {
-        statusCell.appendChild(document.createTextNode(euro.format(charged)));
+        statusCell.appendChild(document.createTextNode(
+          line.is_range
+            ? euro.format(line.display.amount) + "–" + euro.format(line.display_max.amount)
+            : euro.format(charged)));
       } else {
         statusCell.appendChild(el("span", "pill-off",
           line.tier === "optional" ? "optional" : "switched off"));
@@ -259,8 +297,18 @@
     totalRow.appendChild(el("td", null, dep.fees_known ? "True cost" : "Advertised price"));
     totalRow.appendChild(el("td"));
     totalRow.appendChild(el("td"));
-    totalRow.appendChild(el("td", "num", euro.format(m.total)));
+    totalRow.appendChild(el("td", "num", "€" + formatSpan(m)));
     body.appendChild(totalRow);
+
+    if (m.unpriced.length) {
+      var extra = el("tr");
+      var note = el("td", "fee-note",
+        "Plus " + m.unpriced.join(", ") + ": listed by the operator with no price, " +
+        "so it cannot be added up here. It is not free.");
+      note.colSpan = 4;
+      extra.appendChild(note);
+      body.appendChild(extra);
+    }
 
     if (!dep.fees_known) {
       var caveat = el("tr");
@@ -329,7 +377,8 @@
     var sub = el("p", "trip-sub");
     sub.appendChild(document.createTextNode(dateRange(dep)));
     sub.appendChild(el("span", "sep", "·"));
-    sub.appendChild(document.createTextNode(itin.nights + " nights, " + itin.dives + " dives"));
+    sub.appendChild(document.createTextNode(
+      itin.nights + " nights" + (itin.dives > 0 ? ", " + itin.dives + " dives" : "")));
     sub.appendChild(el("span", "sep", "·"));
     sub.appendChild(document.createTextNode(itin.boat));
     left.appendChild(sub);
@@ -342,7 +391,7 @@
     var isOpen = state.open.has(dep.id);
     var button = el("button", "disclose",
       isOpen ? "Hide the breakdown"
-             : dep.fees_known ? "Where does " + euro.format(m.total) + " come from?"
+             : dep.fees_known ? "Where does €" + formatSpan(m) + " come from?"
                               : "What is missing from " + euro.format(m.total) + "?");
     button.type = "button";
     button.setAttribute("aria-expanded", isOpen ? "true" : "false");

--- a/templates/style.css
+++ b/templates/style.css
@@ -364,3 +364,6 @@ table.fees tr.base-row td { background: var(--surface); }
 }
 
 .summary-caveat { color: var(--warn); }
+
+.plus-unpriced { margin-top: 4px; font-size: .76rem; color: var(--warn); }
+.pill-unpriced { color: var(--warn); font-weight: 600; font-size: .76rem; }

--- a/tests/test_fees.py
+++ b/tests/test_fees.py
@@ -1,0 +1,170 @@
+"""Tests for parsing the extras disclosure off a vessel page.
+
+The fixture is the real text from liveaboard.com's Grand Discovery page.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from liveaboard.models import FeeItem
+from liveaboard.scrape.base import FetchResult, PoliteFetcher
+from liveaboard.scrape.fees import parse_extras, to_fee_dicts
+from liveaboard.scrape.liveaboard_com import LiveaboardComAdapter, _page_text
+from liveaboard.taxonomy import FeeCode, FeeTier
+
+REAL = (
+    "Required Extras: Environment Tax (€45), Fuel Surcharge (€60-70 / trip), "
+    "National Park Fees (€35-100 / trip), Port Fees (€35). "
+    "Optional Extras: Gratuities (€80), Nitrox (€30 / trip), "
+    "Nitrox Course (€250 / item), Private Dive Guide (€500 / trip), "
+    "Rental Gear, Scuba Diving Courses (€300-350), "
+    "Laundry / Pressing Services (€5 / item)."
+)
+
+
+def by_code(fees):
+    return {fee.code: fee for fee in fees}
+
+
+class TestRealDisclosure(unittest.TestCase):
+    def setUp(self):
+        self.fees = parse_extras(REAL)
+        self.byc = by_code(self.fees)
+
+    def test_every_extra_is_found(self):
+        self.assertEqual(len(self.fees), 10)
+
+    def test_required_block_becomes_mandatory(self):
+        for code in (
+            FeeCode.ENVIRONMENT_TAX,
+            FeeCode.FUEL_SURCHARGE,
+            FeeCode.MARINE_PARK,
+            FeeCode.PORT_FEES,
+        ):
+            self.assertEqual(self.byc[code].tier, FeeTier.MANDATORY, code)
+
+    def test_ranges_keep_both_ends(self):
+        """Park fees quoted 35-100 are a 65 euro spread; the low end alone lies."""
+        park = self.byc[FeeCode.MARINE_PARK]
+        self.assertTrue(park.is_range)
+        self.assertEqual((park.low, park.high), (35.0, 100.0))
+
+    def test_a_fixed_amount_is_not_a_range(self):
+        self.assertFalse(self.byc[FeeCode.PORT_FEES].is_range)
+
+    def test_an_extra_with_no_figure_has_no_price(self):
+        """Rental Gear is listed and left blank; that is not free."""
+        gear = self.byc[FeeCode.GEAR_RENTAL]
+        self.assertFalse(gear.has_price)
+        self.assertIsNone(gear.low)
+
+    def test_currency_comes_from_the_symbol(self):
+        """The page quotes fees in euro while quoting trip prices in dollars."""
+        self.assertEqual(self.byc[FeeCode.PORT_FEES].currency, "EUR")
+
+    def test_nitrox_course_does_not_resolve_as_nitrox(self):
+        self.assertEqual(self.byc[FeeCode.NITROX].low, 30.0)
+        self.assertEqual(self.byc[FeeCode.COURSE].low, 250.0)
+
+    def test_gratuities_are_customary_despite_being_listed_optional(self):
+        """The site's split says escapable; it does not say who actually escapes."""
+        self.assertEqual(self.byc[FeeCode.GRATUITIES].tier, FeeTier.CUSTOMARY)
+
+    def test_nitrox_is_conditional_so_a_toggle_governs_it(self):
+        self.assertEqual(self.byc[FeeCode.NITROX].tier, FeeTier.CONDITIONAL)
+
+    def test_a_genuine_luxury_stays_optional(self):
+        self.assertEqual(self.byc[FeeCode.PRIVATE_GUIDE].tier, FeeTier.OPTIONAL)
+
+
+class TestFeeDicts(unittest.TestCase):
+    PROV = {"kind": "scraped", "source_id": "liveaboard.com", "retrieved": "2026-08-27"}
+
+    def setUp(self):
+        self.dicts = to_fee_dicts(parse_extras(REAL), self.PROV)
+        self.items = [FeeItem.from_dict(d, "EUR") for d in self.dicts]
+        self.byc = {item.code: item for item in self.items}
+
+    def test_dicts_load_as_fee_items(self):
+        self.assertEqual(len(self.items), 10)
+
+    def test_range_survives_the_round_trip(self):
+        park = self.byc[FeeCode.MARINE_PARK]
+        self.assertTrue(park.is_range)
+        self.assertEqual(float(park.amount.amount), 35.0)
+        self.assertEqual(float(park.amount_max.amount), 100.0)
+
+    def test_missing_price_survives_as_none_not_zero(self):
+        self.assertIsNone(self.byc[FeeCode.GEAR_RENTAL].amount)
+        self.assertFalse(self.byc[FeeCode.GEAR_RENTAL].has_price)
+
+    def test_asking_an_unpriced_fee_for_a_total_raises(self):
+        """Better a loud failure than a silent zero in a cost total."""
+        with self.assertRaises(ValueError):
+            self.byc[FeeCode.GEAR_RENTAL].for_trip(7, 20)
+
+
+class TestExtractionFromMarkup(unittest.TestCase):
+    """The disclosure is split across anchors and spans in real markup."""
+
+    HTML = (
+        "<html><head>"
+        '<script type="application/ld+json">{"@type":"Product","name":"Grand Discovery"}</script>'
+        "</head><body><h3>Required Extras:</h3><ul>"
+        "<li><a>Environment Tax</a> <span>(&euro;45)</span></li>"
+        "<li><a>Fuel Surcharge</a> <span>(&euro;60-70 / trip)</span></li>"
+        "</ul><h3>Optional Extras:</h3><ul>"
+        "<li><a>Nitrox</a> <span>(&euro;30 / trip)</span></li>"
+        "<li><a>Rental Gear</a></li></ul></body></html>"
+    )
+
+    def test_block_ends_become_separators(self):
+        """Without this the entries run together and their boundaries vanish."""
+        text = _page_text(self.HTML)
+        self.assertIn("Environment Tax (€45)", text)
+        # A separator lands between the entries; incidental spacing around it
+        # is the parser's problem, not the flattener's.
+        between = text.split("Environment Tax (€45)")[1].split("Fuel Surcharge")[0]
+        self.assertIn(",", between)
+
+    def test_fees_are_read_off_the_vessel_page(self):
+        adapter = LiveaboardComAdapter(PoliteFetcher(snapshot_dir="/tmp/unused"))
+        output = adapter.parse(
+            FetchResult(
+                url="https://www.liveaboard.com/diving/egypt/grand-discovery",
+                status=200,
+                body=self.HTML,
+                fetched_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+            )
+        )
+        codes = {fee["code"] for fee in output.itineraries[0]["fees"]}
+        self.assertEqual(
+            codes, {"environment_tax", "fuel_surcharge", "nitrox", "gear_rental"}
+        )
+
+    def test_a_page_with_no_disclosure_is_reported(self):
+        adapter = LiveaboardComAdapter(PoliteFetcher(snapshot_dir="/tmp/unused"))
+        output = adapter.parse(
+            FetchResult(
+                url="https://www.liveaboard.com/diving/egypt/quiet-boat",
+                status=200,
+                body='<script type="application/ld+json">{"@type":"Product","name":"X"}</script>',
+                fetched_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+            )
+        )
+        self.assertTrue(any("Extras" in w for w in output.warnings))
+
+
+class TestNoise(unittest.TestCase):
+    def test_absent_blocks_yield_nothing(self):
+        self.assertEqual(parse_extras("A lovely boat with a sun deck."), [])
+
+    def test_unrecognised_labels_are_dropped_not_guessed(self):
+        fees = parse_extras("Required Extras: Sun Cream (€9), Port Fees (€35).")
+        self.assertEqual([f.code for f in fees], [FeeCode.PORT_FEES])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The missing half of the dataset. A vessel page carries this:

> **Required Extras:** Environment Tax (€45), Fuel Surcharge (€60-70 / trip), National Park Fees (€35-100 / trip), Port Fees (€35).
> **Optional Extras:** Gratuities (€80), Nitrox (€30 / trip), Nitrox Course (€250 / item), Private Dive Guide (€500 / trip), Rental Gear, Scuba Diving Courses (€300-350), Laundry / Pressing Services (€5 / item).

Three properties of that text drove the design.

**Ranges.** Half the *required* extras are ranges, and park fees quoted €35–100 are a €65 spread on a supposedly fixed charge. Keeping only the low end would understate the bill — the exact failure this project exists to correct. Both ends survive, and the total is reported as a range:

```
Berth (advertised, converted from $1,600)   €1,472
Environment tax           mandatory            €45
Fuel surcharge            mandatory         €60–70
Marine park fees          mandatory        €35–100
Port & harbour dues       mandatory            €35
Equipment rental          conditional    not stated
Nitrox                    conditional          €30
Crew gratuities           customary            €80
────────────────────────────────────────────────────
True cost                          €1,757 – €1,832    +19%
                    plus equipment rental, price unstated
```

**Unpriced extras.** "Rental Gear" is listed with no figure — a third state, distinct from zero and from absent. It reaches the page as *"payable, amount unknown"* rather than quietly adding nothing.

**Currency.** Fees are in euro on pages whose trip prices are in dollars, so both appear on one vessel; the FX layer already records which numbers it converted.

## How the extras are found

From flattened page text, not selectors. My first probe looked only at **leaf** elements and found nothing, because `Environment Tax (€45)` is split across an anchor and a span — label and amount in different nodes. Flattening reunites them.

But block ends have to become commas *first*. Without that the list items run together as `Environment Tax (€45) Fuel Surcharge (€60-70)…` and the entry boundaries vanish — which cost seven of ten fees on the first attempt.

Fees hang off the **vessel**, not the sailing: the same extras apply whichever month is booked, so they're read once per boat page.

Also adds `environment_tax` and `laundry` to the taxonomy — the site bills both, and an unrecognised code is a fee that silently disappears.

118 tests, up from 99; the fixture is the real disclosure text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_