### PR TITLE
Collect fees with a browser on a weekly schedule

### DIFF
--- a/.github/workflows/fees.yml
+++ b/.github/workflows/fees.yml
@@ -1,0 +1,80 @@
+name: Weekly fee refresh
+
+# Collects vessel fee disclosures with a real browser.
+#
+# Separate from the daily refresh, and slower, because the two have different
+# natures. Prices and availability change constantly and are cheap to fetch.
+# Fees are a property of the vessel and do not change with the month, so
+# re-rendering ninety pages every night would spend a lot of someone else's CPU
+# to learn the same answer.
+#
+# Writes data/fees.json. The daily promote step picks it up if present, so the
+# two schedules stay independent: a failed fee run leaves last week's fees in
+# place rather than blanking them.
+
+on:
+  schedule:
+    # Sundays 03:10 UTC — quiet, and it lands before the daily refresh so the
+    # week starts with fresh fees.
+    - cron: "10 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Cap vessels visited (0 = all)"
+        type: string
+        default: "0"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: fee-refresh
+  cancel-in-progress: false
+
+jobs:
+  fees:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Playwright
+        run: |
+          pip install --quiet playwright
+          playwright install --with-deps chromium
+
+      - name: Collect fees
+        id: collect
+        run: |
+          python3 tools/scrape_fees.py \
+            --out data/fees.json \
+            --limit "${{ inputs.limit || 0 }}"
+
+      - name: Rebuild with the new fees
+        if: steps.collect.outcome == 'success'
+        run: |
+          if [ -f data/candidate.json ]; then
+            PYTHONPATH=src python3 -m liveaboard.cli promote \
+              --candidate data/candidate.json \
+              --fees data/fees.json \
+              --out data/egypt-2027.json
+          fi
+          PYTHONPATH=src python3 -m liveaboard.cli build \
+            --data "$([ -f data/egypt-2027.json ] && echo data/egypt-2027.json || echo data/seed/egypt-2027.json)"
+
+      - name: Commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A data site
+          if git diff --cached --quiet; then
+            echo "fees unchanged this week"
+            exit 0
+          fi
+          git commit -m "data: weekly fee refresh $(date -u +%Y-%m-%d)"
+          git push

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -178,7 +178,21 @@ def cmd_promote(args: argparse.Namespace) -> int:
     """
     candidate = json.loads(Path(args.candidate).read_text(encoding="utf-8"))
     season = (date.fromisoformat(args.season_start), date.fromisoformat(args.season_end))
-    payload = promote(candidate, season=season)
+
+    # Optional: fees collected by the weekly browser run. Absent is normal on a
+    # fresh checkout and must not fail the daily pipeline.
+    fees = None
+    fee_path = Path(args.fees)
+    if fee_path.exists():
+        fees = json.loads(fee_path.read_text(encoding="utf-8"))
+
+    payload = promote(candidate, season=season, fees=fees)
+
+    priced = sum(1 for i in payload["itineraries"] if i["fees"])
+    if fees:
+        print(f"  fees applied to {priced}/{len(payload['itineraries'])} itineraries")
+    else:
+        print(f"  no {fee_path} found; fees will render as unknown")
 
     incoming = len(payload["departures"])
     if incoming == 0:
@@ -247,6 +261,7 @@ def main(argv: list[str] | None = None) -> int:
     promote_cmd = sub.add_parser("promote", help="turn a scrape candidate into the dataset")
     promote_cmd.add_argument("--candidate", default=Path("data/candidate.json"), type=Path)
     promote_cmd.add_argument("--out", default=Path("data/egypt-2027.json"), type=Path)
+    promote_cmd.add_argument("--fees", default=Path("data/fees.json"), type=Path)
     promote_cmd.add_argument("--season-start", default="2027-05-01")
     promote_cmd.add_argument("--season-end", default="2027-08-31")
     promote_cmd.add_argument(

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -51,6 +51,7 @@ def promote(
     season: tuple[date, date] | None = None,
     fx: dict[str, Any] | None = None,
     notes: str | None = None,
+    fees: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a dataset payload from a scrape candidate.
 
@@ -59,6 +60,16 @@ def promote(
     average away the difference between a wreck week and a shark week.
     """
     scraped_boats = {i.get("id"): i for i in candidate.get("itineraries", []) if i.get("id")}
+
+    # Fees come from a separate, slower browser-driven run because the source
+    # renders them client-side. They are keyed by vessel and reused across
+    # every itinerary that vessel sells, which is what the operator does too:
+    # the extras do not change with the month.
+    fee_book: dict[str, list[dict[str, Any]]] = {}
+    if fees:
+        for slug, entry in (fees.get("vessels") or {}).items():
+            if entry.get("fees"):
+                fee_book[slug] = entry["fees"]
 
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     skipped: list[str] = []
@@ -109,9 +120,9 @@ def promote(
                 "dive_sites": _sites_from_name(name),
                 "summary": source.get("summary"),
                 "source_url": source.get("source_url"),
-                # No fee data was scraped. The renderer must show this as
-                # unknown rather than as zero.
-                "fees": [],
+                # Empty when the fee run has not covered this vessel. The
+                # renderer shows that as unknown, never as zero.
+                "fees": fee_book.get(slug, source.get("fees") or []),
             }
         )
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -175,5 +175,76 @@ class TestSlugify(unittest.TestCase):
         self.assertEqual(slugify("Brothers, Daedalus & Elphinstone"), "brothers-daedalus-elphinstone")
 
 
+class TestFeeMerge(unittest.TestCase):
+    """Fees arrive from a separate weekly browser run, keyed by vessel."""
+
+    FEES = {
+        "scraped_at": "2026-08-27",
+        "vessels": {
+            "alia-soul": {
+                "source_url": "https://www.liveaboard.com/diving/egypt/alia-soul",
+                "fees": [
+                    {
+                        "code": "marine_park",
+                        "tier": "mandatory",
+                        "basis": "per_trip",
+                        "included": False,
+                        "amount": {"amount": 35.0, "currency": "EUR"},
+                        "amount_max": {"amount": 100.0, "currency": "EUR"},
+                        "provenance": PROV,
+                    }
+                ],
+            }
+        },
+    }
+
+    def test_fees_reach_the_itinerary(self):
+        payload = promote(candidate([departure()]), season=SEASON, fees=self.FEES)
+        self.assertEqual(len(payload["itineraries"][0]["fees"]), 1)
+
+    def test_the_same_fees_apply_to_every_trip_that_vessel_sells(self):
+        """They are a property of the boat, not the sailing."""
+        payload = promote(
+            candidate(
+                [
+                    departure(name="Brothers, Daedalus & Elphinstone"),
+                    departure(name="Northern Wrecks", start="2027-06-05", end="2027-06-12"),
+                ]
+            ),
+            season=SEASON,
+            fees=self.FEES,
+        )
+        self.assertEqual(len(payload["itineraries"]), 2)
+        for itinerary in payload["itineraries"]:
+            self.assertEqual(len(itinerary["fees"]), 1)
+
+    def test_a_vessel_the_fee_run_missed_stays_unknown(self):
+        """Absent fees must never render as no fees."""
+        payload = promote(
+            candidate(
+                [departure(boat="unvisited")],
+                itineraries=[{"id": "unvisited", "boat": "Unvisited"}],
+            ),
+            season=SEASON,
+            fees=self.FEES,
+        )
+        self.assertEqual(payload["itineraries"][0]["fees"], [])
+
+    def test_no_fee_file_at_all_is_not_an_error(self):
+        payload = promote(candidate([departure()]), season=SEASON, fees=None)
+        self.assertEqual(payload["itineraries"][0]["fees"], [])
+
+    def test_merged_fees_produce_a_cost_range(self):
+        from liveaboard.pricing import compute
+
+        dataset = Dataset.from_dict(
+            promote(candidate([departure()]), season=SEASON, fees=self.FEES)
+        )
+        itinerary = next(iter(dataset.itineraries.values()))
+        breakdown = compute(itinerary, dataset.departures[0], dataset.fx)
+        self.assertTrue(breakdown.is_range)
+        self.assertGreater(breakdown.total_max.amount, breakdown.total.amount)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scrape_fees.py
+++ b/tools/scrape_fees.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Collect vessel fee disclosures with a real browser.
+
+liveaboard.com does not serve the "Required Extras" block in its HTML — a full
+crawl found it on none of eleven vessel pages. It is rendered client-side, so
+the dependency-free scraper cannot reach it and a browser has to.
+
+This runs separately from the daily scrape and on a slower schedule, because
+the two have different natures. Prices and availability change constantly and
+are cheap to fetch. **Fees are a property of the vessel and do not change with
+the month**, so re-rendering ninety pages every night would be a lot of
+someone else's CPU for an answer that is nearly always the same.
+
+Output is ``data/fees.json``, keyed by vessel slug, which ``promote`` merges
+into itineraries. Parsing is shared with the daily path via
+``liveaboard.scrape.fees`` — one implementation of what a fee means.
+
+    python3 tools/scrape_fees.py --out data/fees.json [--limit N] [--delay 4]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from liveaboard.scrape.fees import parse_extras, to_fee_dicts  # noqa: E402
+from liveaboard.scrape.liveaboard_com import (  # noqa: E402
+    HOST,
+    SEASON_QUERY,
+    LiveaboardComAdapter,
+    search_paths,
+)
+
+CHROMIUM = "/opt/pw-browsers/chromium-1194/chrome-linux/chrome"
+
+# Buttons that reveal collapsed detail. The live page carries a "+4" control,
+# and the extras may sit behind it.
+EXPANDERS = re.compile(r"^\s*(\+\d+|show all.*|more.*|read more)\s*$", re.I)
+
+EXTRAS_MARKER = re.compile(r"(Required|Optional)\s+Extras", re.I)
+
+
+def boat_slugs(page: Any, limit: int) -> list[str]:
+    """Vessel paths for the season, taken from the month search pages.
+
+    Read through the browser rather than over plain HTTP so this tool stands
+    alone: it needs no prior scrape output to run.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for path in search_paths():
+        page.goto(f"https://{HOST}{path}", wait_until="domcontentloaded", timeout=60000)
+        for link in sorted(LiveaboardComAdapter.boat_links(page.content())):
+            if link not in seen:
+                seen.add(link)
+                found.append(link)
+        if limit and len(found) >= limit:
+            break
+    return found[:limit] if limit else found
+
+
+def read_extras(page: Any, url: str) -> tuple[str, bool]:
+    """Return the page's visible text, expanding collapsed sections if needed.
+
+    Tries the plain rendered text first. A previous probe concluded the block
+    was absent when it was only being filtered out by a bad selector, so this
+    reads the whole body before assuming anything is hidden.
+    """
+    page.goto(url, wait_until="domcontentloaded", timeout=60000)
+    page.wait_for_timeout(1200)
+
+    text = page.evaluate("() => document.body.innerText || ''")
+    if EXTRAS_MARKER.search(text):
+        return text, False
+
+    # Not in the rendered text: try the disclosure controls.
+    clicked = 0
+    for button in page.query_selector_all("button, [role='button'], summary, a[href='#']"):
+        try:
+            label = (button.inner_text() or "").strip()
+        except Exception:  # noqa: BLE001 - a detached node is not a failure
+            continue
+        if not EXPANDERS.match(label):
+            continue
+        try:
+            button.click(timeout=2000)
+            clicked += 1
+            page.wait_for_timeout(250)
+        except Exception:  # noqa: BLE001 - an unclickable control is not a failure
+            continue
+
+    if clicked:
+        page.wait_for_timeout(600)
+        text = page.evaluate("() => document.body.innerText || ''")
+    return text, clicked > 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default=Path("data/fees.json"), type=Path)
+    parser.add_argument("--limit", type=int, default=0, help="cap vessels (0 = all)")
+    parser.add_argument("--delay", type=float, default=4.0, help="seconds between vessels")
+    parser.add_argument("--executable", default=None)
+    args = parser.parse_args()
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("playwright missing: pip install playwright && playwright install chromium")
+        return 2
+
+    launch: dict[str, Any] = {"args": ["--no-sandbox"]}
+    executable = args.executable or (CHROMIUM if Path(CHROMIUM).exists() else None)
+    if executable:
+        launch["executable_path"] = executable
+
+    collected: dict[str, Any] = {}
+    missing: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(**launch)
+        page = browser.new_page(viewport={"width": 1400, "height": 1200})
+
+        slugs = boat_slugs(page, args.limit)
+        print(f"{len(slugs)} vessels to visit", flush=True)
+
+        for index, link in enumerate(slugs, 1):
+            slug = link.rstrip("/").rsplit("/", 1)[-1]
+            url = f"https://{HOST}{link}{SEASON_QUERY}"
+            try:
+                text, expanded = read_extras(page, url)
+            except Exception as exc:  # noqa: BLE001 - one bad page must not end the run
+                print(f"  [{index}/{len(slugs)}] {slug}: navigation failed: {exc}", flush=True)
+                missing.append(slug)
+                continue
+
+            fees = parse_extras(text)
+            if not fees:
+                print(f"  [{index}/{len(slugs)}] {slug}: no extras found", flush=True)
+                missing.append(slug)
+            else:
+                required = sum(1 for f in fees if f.tier.value == "mandatory")
+                ranges = sum(1 for f in fees if f.is_range)
+                unpriced = sum(1 for f in fees if not f.has_price)
+                collected[slug] = {
+                    "source_url": url,
+                    "fees": to_fee_dicts(
+                        fees,
+                        {
+                            "kind": "scraped",
+                            "source_id": "liveaboard.com",
+                            "retrieved": date.today().isoformat(),
+                            "url": url,
+                        },
+                    ),
+                }
+                print(
+                    f"  [{index}/{len(slugs)}] {slug}: {len(fees)} extras "
+                    f"({required} required, {ranges} ranged, {unpriced} unpriced)"
+                    + (" [expanded]" if expanded else ""),
+                    flush=True,
+                )
+            page.wait_for_timeout(int(args.delay * 1000))
+
+        browser.close()
+
+    if not collected:
+        print("no fees collected from any vessel", file=sys.stderr)
+        return 1
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(
+            {
+                "scraped_at": date.today().isoformat(),
+                "source": "liveaboard.com",
+                "vessels": collected,
+                "missing": missing,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"\nwrote {args.out}: {len(collected)} vessels with fees, {len(missing)} without")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
A full crawl found **no Required/Optional Extras block on any of eleven vessel pages**:

```
11  no Required/Optional Extras block in server HTML
```

liveaboard.com renders the disclosure client-side, so the dependency-free scraper can't reach it. `tools/scrape_fees.py` drives a real browser instead.

It reads **body text** rather than selecting elements — an earlier probe concluded the block was absent when it was only being filtered out by a leaf-element selector, so this looks at everything before assuming anything is hidden. If the extras still aren't in the rendered text, it clicks the page's disclosure controls (the live page carries a `+4` expander) and re-reads.

## Why weekly, not daily

The two scrapes have different natures:

| | Prices & availability | Fees |
| --- | --- | --- |
| Change | constantly | rarely — and *not with the month*, as confirmed |
| Cost to fetch | cheap HTTP | full browser render, ~90 pages |
| Schedule | daily | Sundays 03:10 UTC |

Re-rendering ninety pages every night would spend a lot of someone else's CPU to learn the same answer.

## The schedules stay independent

The fee run writes `data/fees.json`; `promote` merges it when present. So a failed fee run leaves **last week's fees in place** rather than blanking them, and a vessel the run missed renders as **unknown** rather than as having none — the distinction the whole project turns on.

Fees are keyed by vessel and reused across every itinerary that vessel sells, which is what the operator does too.

Playwright stays out of the package; the tool imports only the shared fee parser, so there's one implementation of what a fee means.

125 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_