### PR TITLE
Recover fee amounts from a browser's line-broken text

### DIFF
--- a/src/liveaboard/scrape/fees.py
+++ b/src/liveaboard/scrape/fees.py
@@ -163,10 +163,49 @@ def _number(raw: str | None) -> float | None:
         return None
 
 
+CONTINUATION = re.compile(r"^\s*[(\-–—/]")
+"""A line that continues the one above rather than starting a new entry."""
+
+
+def normalise_disclosure(text: str) -> str:
+    """Turn a browser's ``innerText`` into comma-separated entries.
+
+    Rendered text puts each extra on its own line and often its amount on the
+    next one again::
+
+        Environment Tax
+        (€45)
+        Fuel Surcharge
+        (€60-70 / trip)
+
+    Naively swapping every newline for a comma separates each label from its
+    own price and silently reports seven priced extras as unpriced — worse than
+    the run-together text it was meant to fix. So a line opening with a bracket
+    or a dash is rejoined to the line above, and only the remaining breaks
+    become separators.
+
+    Idempotent on text that is already comma-separated, so both the raw-HTML
+    and rendered-text paths can call it.
+    """
+    joined: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if joined and CONTINUATION.match(line):
+            joined[-1] = f"{joined[-1]} {line}"
+        else:
+            joined.append(line)
+    return ", ".join(joined)
+
+
 def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
     """Extract every stated extra from a vessel page's disclosure text."""
     found: list[ParsedFee] = []
     seen: set[FeeCode] = set()
+
+    if "\n" in text:
+        text = normalise_disclosure(text)
 
     for required_word, body in BLOCK.findall(text):
         required = required_word.lower() == "required"

--- a/tests/test_fees.py
+++ b/tests/test_fees.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 
 from liveaboard.models import FeeItem
 from liveaboard.scrape.base import FetchResult, PoliteFetcher
-from liveaboard.scrape.fees import parse_extras, to_fee_dicts
+from liveaboard.scrape.fees import normalise_disclosure, parse_extras, to_fee_dicts
 from liveaboard.scrape.liveaboard_com import LiveaboardComAdapter, _page_text
 from liveaboard.taxonomy import FeeCode, FeeTier
 
@@ -164,6 +164,43 @@ class TestNoise(unittest.TestCase):
     def test_unrecognised_labels_are_dropped_not_guessed(self):
         fees = parse_extras("Required Extras: Sun Cream (€9), Port Fees (€35).")
         self.assertEqual([f.code for f in fees], [FeeCode.PORT_FEES])
+
+
+class TestRenderedTextLayout(unittest.TestCase):
+    """A browser's innerText puts each extra, and often its amount, on its own line."""
+
+    INNER = (
+        "Required Extras:\n"
+        "Environment Tax\n(\u20ac45)\n"
+        "Fuel Surcharge\n(\u20ac60-70 / trip)\n"
+        "National Park Fees\n(\u20ac35-100 / trip)\n"
+        "Optional Extras:\n"
+        "Gratuities\n(\u20ac80)\n"
+        "Rental Gear"
+    )
+
+    def setUp(self):
+        self.byc = by_code(parse_extras(self.INNER))
+
+    def test_amounts_survive_the_line_break(self):
+        """Swapping every newline for a comma orphans each label from its price."""
+        self.assertEqual(self.byc[FeeCode.ENVIRONMENT_TAX].low, 45.0)
+        self.assertEqual(self.byc[FeeCode.GRATUITIES].low, 80.0)
+
+    def test_ranges_survive_the_line_break(self):
+        park = self.byc[FeeCode.MARINE_PARK]
+        self.assertEqual((park.low, park.high), (35.0, 100.0))
+
+    def test_a_genuinely_unpriced_extra_is_still_unpriced(self):
+        self.assertFalse(self.byc[FeeCode.GEAR_RENTAL].has_price)
+
+    def test_only_one_extra_lacks_a_price(self):
+        """A first live run reported five to seven per vessel; that was the bug."""
+        unpriced = [f for f in parse_extras(self.INNER) if not f.has_price]
+        self.assertEqual(len(unpriced), 1)
+
+    def test_normalising_is_idempotent_on_comma_separated_text(self):
+        self.assertEqual(len(parse_extras(REAL)), len(parse_extras(normalise_disclosure(REAL))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The first browser run found extras on **all five vessels it visited** — and misread most of their prices:

```
alia-soul         9 extras  (2 required, 0 ranged, 5 unpriced)
all-star-red-sea 10 extras  (1 required, 0 ranged, 7 unpriced)
```

Five to seven unpriced per vessel, when the real page has **one**.

Rendered text puts each extra on its own line, and often its amount on the line after that:

```
Environment Tax
(€45)
Fuel Surcharge
(€60-70 / trip)
```

The entry parser only terminates on a comma, a full stop, or end of input — so the amounts never attached.

**Swapping every newline for a comma is worse, not better**: it orphans each label from its own price and turns *all seven* unpriced. The separator is the newline **before a label**, not the one inside an entry. So a line opening with a bracket or dash rejoins the line above, and only the remaining breaks become separators.

Normalising is idempotent on already-comma-separated text, so the raw-HTML and rendered-text paths share one parser and one notion of what an entry is.

This is the **third appearance of the same bug** — entries whose boundaries are structural rather than punctuated, flattened without preserving them. It cost seven of ten fees in HTML, and now seven of nine in `innerText`. Tests pin both layouts.

130 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_