### PR TITLE
Rebase and retry when a scheduled push is rejected

### DIFF
--- a/.github/workflows/fees.yml
+++ b/.github/workflows/fees.yml
@@ -76,5 +76,22 @@ jobs:
             echo "fees unchanged this week"
             exit 0
           fi
+          # Every run is a commit, so the git history doubles as price history:
+          # `git log -p data/` shows exactly which fee moved, and when.
           git commit -m "data: weekly fee refresh $(date -u +%Y-%m-%d)"
-          git push
+
+          # A scrape takes minutes, and anything can land on main meanwhile --
+          # the other scheduled job, or a merge. A plain push is rejected and
+          # the whole run's data is thrown away. Rebase and retry instead.
+          # -X theirs favours the commit being replayed, which is ours: these
+          # files are regenerated output, so the fresh copy always wins.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt); rebasing onto origin/main"
+            git fetch origin main
+            git rebase -X theirs origin/main || { git rebase --abort; exit 1; }
+          done
+          echo "::error::could not push after 3 attempts"
+          exit 1

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -111,4 +111,19 @@ jobs:
           # Every run is a commit, so the git history doubles as price history:
           # `git log -p data/` shows exactly which fee moved, and when.
           git commit -m "data: daily refresh $(date -u +%Y-%m-%d)"
-          git push
+
+          # A scrape takes minutes, and anything can land on main meanwhile --
+          # the other scheduled job, or a merge. A plain push is rejected and
+          # the whole run's data is thrown away. Rebase and retry instead.
+          # -X theirs favours the commit being replayed, which is ours: these
+          # files are regenerated output, so the fresh copy always wins.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt); rebasing onto origin/main"
+            git fetch origin main
+            git rebase -X theirs origin/main || { git rebase --abort; exit 1; }
+          done
+          echo "::error::could not push after 3 attempts"
+          exit 1


### PR DESCRIPTION
Run 4 scraped, promoted, validated and built cleanly — then threw all of it away at the push:

```
[main 1b6f0f5] data: daily refresh 2026-08-27
 3 files changed, 10708 insertions(+), 13354 deletions(-)
 ! [rejected]  main -> main (fetch first)
```

Two merges landed on `main` during the eight minutes it spent crawling. The commit step assumed nothing else would ever touch the branch. With a daily scrape, a weekly fee run and ordinary merges all writing there, that was only ever going to hold until it didn't — and the cost is an entire run's data, which is the expensive half of the job.

Both workflows now rebase onto `origin/main` and retry, up to three times. `-X theirs` favours the commit being replayed, which is ours: `data/` and `site/` are regenerated output, so the freshly built copy always wins over whatever landed meanwhile. A rebase that can't be resolved aborts rather than pushing a half-merged dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_