### PR TITLE
Fix the force flag never reaching promote

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -70,7 +70,7 @@ jobs:
           PYTHONPATH=src python3 -m liveaboard.cli promote \
             --candidate data/candidate.json \
             --out data/egypt-2027.json \
-            ${{ inputs.force_promote == 'true' && '--force' || '' }}
+            ${{ inputs.force_promote && '--force' || '' }}
 
       - name: Report a blocked or empty scrape
         if: steps.scrape.outcome == 'failure'

--- a/data/candidate.json
+++ b/data/candidate.json
@@ -93,9 +93,90 @@
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "alia-soul",
+      "name": "Alia Soul",
+      "boat": "Alia Soul",
+      "summary": "Dive the Red Sea aboard the Alia Soul liveaboard, a 36m (118ft) diving boat with 10 cabins for 20 guests, spacious dive decks, Nitrox, and itineraries to top northern and southern dive sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+      },
+      "fees": [
+        {
+          "code": "environment_tax",
+          "tier": "mandatory",
+          "basis": "per_night",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+          },
+          "amount": {
+            "amount": 24.0,
+            "currency": "EUR"
+          }
         },
         {
-          "code": "airport_transfer",
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+          },
+          "amount": {
+            "amount": 80.0,
+            "currency": "EUR"
+          },
+          "note": "Port Fees"
+        },
+        {
+          "code": "course",
+          "tier": "optional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+          },
+          "amount": {
+            "amount": 99.0,
+            "currency": "EUR"
+          },
+          "note": "Nitrox Course"
+        },
+        {
+          "code": "private_guide",
+          "tier": "optional",
+          "basis": "per_day",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+          },
+          "amount": {
+            "amount": 50.0,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
           "tier": "conditional",
           "basis": "per_trip",
           "included": false,
@@ -103,13 +184,94 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
           },
           "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "alia-soul",
+      "name": "Alia Soul",
+      "boat": "Alia Soul",
+      "summary": "Dive the Red Sea aboard the Alia Soul liveaboard, a 36m (118ft) diving boat with 10 cabins for 20 guests, spacious dive decks, Nitrox, and itineraries to top northern and southern dive sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
+      },
+      "fees": [
+        {
+          "code": "environment_tax",
+          "tier": "mandatory",
+          "basis": "per_night",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
+          },
+          "amount": {
+            "amount": 24.0,
+            "currency": "EUR"
+          }
         },
         {
-          "code": "nitrox",
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
+          },
+          "amount": {
+            "amount": 80.0,
+            "currency": "EUR"
+          },
+          "note": "Port Fees"
+        },
+        {
+          "code": "course",
+          "tier": "optional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
+          },
+          "amount": {
+            "amount": 99.0,
+            "currency": "EUR"
+          },
+          "note": "Nitrox Course"
+        },
+        {
+          "code": "private_guide",
+          "tier": "optional",
+          "basis": "per_day",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
+          },
+          "amount": {
+            "amount": 50.0,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
           "tier": "conditional",
           "basis": "per_trip",
           "included": false,
@@ -117,13 +279,61 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027"
           },
           "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "alia-soul",
+      "name": "Alia Soul",
+      "boat": "Alia Soul",
+      "summary": "Dive the Red Sea aboard the Alia Soul liveaboard, a 36m (118ft) diving boat with 10 cabins for 20 guests, spacious dive decks, Nitrox, and itineraries to top northern and southern dive sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
+      },
+      "fees": [
+        {
+          "code": "environment_tax",
+          "tier": "mandatory",
+          "basis": "per_night",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
+          },
+          "amount": {
+            "amount": 24.0,
+            "currency": "EUR"
+          }
         },
         {
-          "code": "tax_vat",
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
+          },
+          "amount": {
+            "amount": 80.0,
+            "currency": "EUR"
+          },
+          "note": "Port Fees"
+        },
+        {
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -131,66 +341,43 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
           },
-          "amount": null,
-          "note": "Year built 2014 Year renovated 2025 Length 36 meters Deck area 260 sq: listed with no price"
+          "amount": {
+            "amount": 99.0,
+            "currency": "EUR"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "fuel_surcharge",
+          "code": "private_guide",
           "tier": "optional",
-          "basis": "per_trip",
+          "basis": "per_day",
           "included": false,
           "provenance": {
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
           },
-          "amount": null,
-          "note": "meters Top speed 11 Knots Cruising speed 11 Knots Engines 2x Caterpillar 450 hp Max guests 20 Number of cabins 10 Number of bathrooms 12 Tenders 1 x Yamaha 100hp 1x Yamaha 40hp Water capacity 18 tons Fuel capacity 12 tons Freshwater maker 10000 liters per day: listed with no price"
+          "amount": {
+            "amount": 50.0,
+            "currency": "EUR"
+          }
         },
         {
-          "code": "gratuities",
-          "tier": "customary",
+          "code": "gear_rental",
+          "tier": "conditional",
           "basis": "per_trip",
           "included": false,
           "provenance": {
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
           },
           "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
+          "note": "Rental Gear: listed with no price"
         }
       ]
     },
@@ -298,9 +485,55 @@
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-ghani",
+      "name": "All Star Ghani",
+      "boat": "All Star Ghani",
+      "summary": "Explore the Red Sea aboard the All Star Ghani liveaboard, offering 12 cabins for 24 guests, up to 18 dives weekly, and access to Egypt&rsquo;s top reefs, wrecks, and shark hotspots.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+      },
+      "fees": [
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+          },
+          "amount": {
+            "amount": 200.0,
+            "currency": "USD"
+          },
+          "note": "Port Fees"
         },
         {
-          "code": "airport_transfer",
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
           "tier": "conditional",
           "basis": "per_trip",
           "included": false,
@@ -308,13 +541,15 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
           },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
         },
         {
-          "code": "tax_vat",
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -322,13 +557,16 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
           },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Internet En-Suite bathrooms Aircon Cabins Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck Hair Dryer in Cabin BBQ Area Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Naturalist Guide: listed with no price"
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "fuel_surcharge",
+          "code": "private_guide",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -336,13 +574,89 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
           },
           "amount": null,
-          "note": "Year built 2003 Year renovated 2025 Length 138 feet Beam 25 feet Cruising speed 10 knots Engines 2x Model Man 1300 HP Max guests 24 Number of cabins 12 Number of bathrooms 14 Tenders 2 Water capacity 170000 liters Fuel capacity 25485 liters Freshwater maker 600 liters per hour: listed with no price"
+          "note": "Private Dive Guide: listed with no price"
         },
         {
-          "code": "marine_park",
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+          },
+          "amount": null,
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-ghani",
+      "name": "All Star Ghani",
+      "boat": "All Star Ghani",
+      "summary": "Explore the Red Sea aboard the All Star Ghani liveaboard, offering 12 cabins for 24 guests, up to 18 dives weekly, and access to Egypt&rsquo;s top reefs, wrecks, and shark hotspots.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+      },
+      "fees": [
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+          },
+          "amount": {
+            "amount": 200.0,
+            "currency": "USD"
+          },
+          "note": "Port Fees"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+          },
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
+        },
+        {
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -350,13 +664,16 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
           },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "visa",
+          "code": "private_guide",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -364,10 +681,131 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
           },
           "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
+          "note": "Private Dive Guide: listed with no price"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+          },
+          "amount": null,
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-ghani",
+      "name": "All Star Ghani",
+      "boat": "All Star Ghani",
+      "summary": "Explore the Red Sea aboard the All Star Ghani liveaboard, offering 12 cabins for 24 guests, up to 18 dives weekly, and access to Egypt&rsquo;s top reefs, wrecks, and shark hotspots.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      },
+      "fees": [
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": {
+            "amount": 200.0,
+            "currency": "USD"
+          },
+          "note": "Port Fees"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
+        },
+        {
+          "code": "course",
+          "tier": "optional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
+        },
+        {
+          "code": "private_guide",
+          "tier": "optional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": null,
+          "note": "Private Dive Guide: listed with no price"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+          },
+          "amount": null,
+          "note": "Rental Gear: listed with no price"
         }
       ]
     },
@@ -461,9 +899,55 @@
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-red-sea",
+      "name": "All Star Scuba Scene",
+      "boat": "All Star Scuba Scene",
+      "summary": "Red Sea wrecks and reefs! All Star Scuba Scene takes you to Egypt's iconic dive sites and untouched treasures",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+      },
+      "fees": [
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+          },
+          "amount": {
+            "amount": 250.0,
+            "currency": "USD"
+          },
+          "note": "National Park Fees"
         },
         {
-          "code": "airport_transfer",
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
           "tier": "conditional",
           "basis": "per_trip",
           "included": false,
@@ -471,13 +955,15 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
           },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
         },
         {
-          "code": "laundry",
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -485,13 +971,92 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
           },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Internet Jacuzzi / Hot Tub Naturalist Guide En-Suite bathrooms Aircon Cabins Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Nearly 1:1 Crew-to-Guest Ratio Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Laundry Service Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "tax_vat",
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+          },
+          "amount": null,
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-red-sea",
+      "name": "All Star Scuba Scene",
+      "boat": "All Star Scuba Scene",
+      "summary": "Red Sea wrecks and reefs! All Star Scuba Scene takes you to Egypt's iconic dive sites and untouched treasures",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+      },
+      "fees": [
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+          },
+          "amount": {
+            "amount": 250.0,
+            "currency": "USD"
+          },
+          "note": "National Park Fees"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+          },
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
+        },
+        {
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -499,13 +1064,92 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
           },
-          "amount": null,
-          "note": "Year built 2023 Year renovated 2023 Length 48: listed with no price"
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "fuel_surcharge",
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+          },
+          "amount": null,
+          "note": "Rental Gear: listed with no price"
+        }
+      ]
+    },
+    {
+      "id": "all-star-red-sea",
+      "name": "All Star Scuba Scene",
+      "boat": "All Star Scuba Scene",
+      "summary": "Red Sea wrecks and reefs! All Star Scuba Scene takes you to Egypt's iconic dive sites and untouched treasures",
+      "source_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+      },
+      "fees": [
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+          },
+          "amount": {
+            "amount": 250.0,
+            "currency": "USD"
+          },
+          "note": "National Park Fees"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+          },
+          "amount": null,
+          "note": "Gratuities: listed with no price"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "scraped",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+          },
+          "amount": {
+            "amount": 100.0,
+            "currency": "USD"
+          }
+        },
+        {
+          "code": "course",
           "tier": "optional",
           "basis": "per_trip",
           "included": false,
@@ -513,38 +1157,27 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
           },
-          "amount": null,
-          "note": "5 meters Top speed 14 knots Cruising speed 10 knots Engines 2x Mantrac 1300HP Max guests 28 Number of cabins 14 Number of bathrooms 17 Tenders 3 Water capacity 16 tons Fuel capacity 60 tons Freshwater maker 20 tons/day: listed with no price"
+          "amount": {
+            "amount": 182.0,
+            "currency": "USD"
+          },
+          "note": "Nitrox Course"
         },
         {
-          "code": "visa",
-          "tier": "optional",
+          "code": "gear_rental",
+          "tier": "conditional",
           "basis": "per_trip",
           "included": false,
           "provenance": {
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
           },
           "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
-          },
-          "amount": null,
-          "note": "The dive guides and dive management were always available for questions and problems and took care of all matters promptly: listed with no price"
+          "note": "Rental Gear: listed with no price"
         }
       ]
     },
@@ -645,464 +1278,32 @@
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2024 Length 37 meters Beam 8 meters Top speed 16 knots Cruising speed 10 knots Engines 2x Mercedes turbo diesel 1000HP Max guests 24 Number of cabins 12 Number of bathrooms 14 Tenders 2x Yamaha 85HP Water capacity 8000 liters Fuel capacity 15710 liters Freshwater maker 20000 liters per day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
         }
       ]
     },
     {
-      "id": "amelie",
-      "name": "Amelie",
-      "boat": "Amelie",
-      "summary": "With only 12 guests onboard the Amelie Safari offers a more bespoke Red Sea liveaboard experience.Choose from 3 or 7-night dive itineraries.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027",
+      "id": "alsuraya",
+      "name": "ALSURAYA",
+      "boat": "ALSURAYA",
+      "summary": "The ALSURAYA is a Red Sea liveaboard offering spacious cabins, top-tier amenities, and unforgettable diving and kiteboarding adventures across world-class sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": {
-            "amount": 15.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": {
-            "amount": 25.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": {
-            "amount": 132.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": {
-            "amount": 55.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Sun Deck Camera Station Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "amelie-adventures",
-      "name": "Amelie Adventures",
-      "boat": "Amelie Adventures",
-      "summary": "The Amelie Adventures is a 27-meter/88.6-foot-long liveaboard taking 16 guests on diving adventures in the Red Sea. Snorkeler friendly and available for charters.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
       },
       "fees": [
         {
           "code": "marine_park",
           "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": {
-            "amount": 15.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
           "basis": "per_trip",
           "included": false,
           "provenance": {
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": {
-            "amount": 20.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": {
-            "amount": 132.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": {
-            "amount": 55.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Nitrox Shaded Diving Area DIN Adaptors Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Beam 7 meters Top speed 12 knots Cruising speed 10 knots Engines 2x MAN 600HP Max guests 16 Number of cabins 8 Number of bathrooms 10 Tenders 2 Water capacity 5000 liters Fuel capacity 5000 liters Freshwater maker 7000 liters per day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "aphrodite",
-      "name": "Aphrodite",
-      "boat": "Aphrodite",
-      "summary": "The MY Aphrodite offers year-round dive safaris in the Egyptian Red Sea. Itineraries cover the best Red Sea dive areas, from northern dive sites such as Ras Mohammed to the deep south of St. Johns.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
           },
           "amount": {
             "amount": 150.0,
@@ -1112,1429 +1313,6 @@
             "amount": 250.0,
             "currency": "EUR"
           },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Laundry / Pressing Services: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment TV in cabins Observation Deck BBQ Area Available for Charter Local & International Crew Snorkeling Equipment Outside Showers Leisure Deck Daily housekeeping Bar Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "ashrafi",
-      "name": "ASHRAFI",
-      "boat": "ASHRAFI",
-      "summary": "Sail the Red Sea aboard the ASHRAFI Liveaboard. Enjoy dive safaris, ensuite cabins, gourmet dining, and island-hopping from Hurghada.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": {
-            "amount": 145.0,
-            "currency": "EUR"
-          },
-          "note": "Port and Fuel Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Wakeboarding Boutique / Souvenir Shop Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck Hair Dryer in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "avo",
-      "name": "AVO",
-      "boat": "AVO",
-      "summary": "The AVO offers Red Sea diving and 12 ensuite cabins, spacious decks, fresh cuisine, and expertly curated dive itineraries from Ras Mohamed to St. John&rsquo;s.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 450.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": {
-            "amount": 180.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": {
-            "amount": 550.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "Boat features Food & Drinks Diving Languages Spoken Gear Rental Boat Specifications Boat navigation and safety: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Rooms with Balcony Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment TV in cabins Observation Deck Hair Dryer in Cabin BBQ Area Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/avo?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "bella-2",
-      "name": "Bella 2",
-      "boat": "Bella 2",
-      "summary": "The Bella 2 is a 35-meter/115-foot-long liveaboard taking 24 guests on diving safaris in Egypt&rsquo;s Red Sea, including Brothers, Daedalus, Elphinstone reefs, the Thistegorm wreck, and more.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 5.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Airport Transfer: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Laundry / Pressing Services: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Shaded Diving Area DIN Adaptors Dive deck: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2017 Year renovated Every Year Length 26 meters Top speed 8 knots Cruising speed 7 knots Max guests 22 Number of cabins 11 Number of bathrooms 14 Tenders 2 Water capacity 6000 liters Fuel capacity 5000 liters: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Each cabin includes a private bathroom and is equipped with WiFi: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "bella-3",
-      "name": "Bella 3",
-      "boat": "Bella 3",
-      "summary": "The Bella 3 is a 32-meter/105-foot-long liveaboard taking 20 guests on diving safaris in Egypt&rsquo;s Red Sea, including Brothers, Daedalus, Elphinstone reefs, the Thistegorm wreck, and more.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": {
-            "amount": 5.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "note": "Airport Transfer"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "Laundry / Pressing Services: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Shaded Diving Area DIN Adaptors Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2020 Year renovated 2023 Length 29: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 10 knots Cruising speed 9 knots Engines 2 Max guests 20 Number of cabins 10 Number of bathrooms 14 Tenders 2 Water capacity 3000 liters Fuel capacity 4000 liters: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "bismarck",
-      "name": "Bismarck",
-      "boat": "Bismarck",
-      "summary": "Experience luxury and adventure aboard the Bismarck, a 46-meter Red Sea liveaboard offering 17 cabins and thrilling dives in sites like Brothers, Daedalus, and Ras Muhammad.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": {
-            "amount": 130.0,
-            "currency": "EUR"
-          },
-          "note": "Park and Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "Airport Transfer: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Laundry Service Outdoor Dining Audio & video entertainment Smart Voyager accreditation Hair Dryer in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Central aircon Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue",
-      "name": "Blue",
-      "boat": "Blue",
-      "summary": "The MY Blue is a modern liveaboard offering luxury Red Sea dive trips. Catering for 24 guests, all cabins are en-suite, and sea-view rooms are available.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": {
-            "amount": 290.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 320.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rebreather Support Rinse Hoses Dive deck Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "Recommended for Great crew & dive guides: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue?m=5/2027"
-          },
-          "amount": null,
-          "note": "We would go on a liveaboard with you again at any time and can recommend Blue without reservation! Recommended for Crew: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-diamond",
-      "name": "Blue Diamond",
-      "boat": "Blue Diamond",
-      "summary": "Dive the Red Sea aboard Blue Diamond, a 35m liveaboard for 28 guests, with 14 ensuite cabins, spacious social areas, and varied itineraries.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 250.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "Airport Transfer: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Seaview Cabins Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Hair Dryer in Cabin Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-horizon",
-      "name": "Blue Horizon",
-      "boat": "Blue Horizon",
-      "summary": "The award-winning Blue Horizon yacht offers fantastic Red Sea dive safaris covering all the world-class dive sites of Egypt.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": {
-            "amount": 8.0,
-            "currency": "USD"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": {
-            "amount": 90.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "USD"
-          },
           "note": "Operator quotes \"National Park Fees\" as a range"
         },
         {
@@ -2546,7555 +1324,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": {
-            "amount": 90.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 135.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2006 Year renovated 2016 Length 41 meters Beam 8: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-melody",
-      "name": "Blue Melody",
-      "boat": "Blue Melody",
-      "summary": "The Blue Melody yacht offers year-round diving in the Red Sea. She caters to 26 divers in 13 air-conditioned, ensuite cabins.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_night",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": {
-            "amount": 8.0,
-            "currency": "USD"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": {
-            "amount": 90.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": {
-            "amount": 90.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 135.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2007 Year renovated 2016 Length 38 meters Beam 8: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-pearl",
-      "name": "Blue Pearl",
-      "boat": "Blue Pearl",
-      "summary": "The Blue Pearl liveaboard combines comfort with convenience. En-suite cabins and multiple lounging areas offer relaxation in between exciting Red Sea dives.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 230.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 320.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rebreather Support Rinse Hoses Dive deck: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Our dive guide planned the dives brilliantly taking into account everyone&#x27;s preferences and the conditions: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "The boat has been renovated and is super lovely: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-seas",
-      "name": "Blue Seas",
-      "boat": "Blue Seas",
-      "summary": "Join the Blue Seas liveaboard for a 7-night itinerary at some of the the Red Sea's most iconic dive sites. Double and twin cabins with en-suite bathrooms.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 380.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Rebreather Support Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2004 Year renovated 2013 Length 37 meters Beam 8 meters Top speed 16 knots Cruising speed 13 knots Engines 2 x Caterpillar: V12 Cylinders 3412cc: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "crew and dive guides 19 Aug: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "blue-storm",
-      "name": "Blue Storm",
-      "boat": "Blue Storm",
-      "summary": "The Blue Storm is a modern liveaboard operating in the Red Sea, Egypt. With 24 guests maximum, 11 Double cabins all with en-suite facilities, Blue Storm visits the most popular dive sites in the Red Sea.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 380.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "motivated crew: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "We will come again Recommended for Good dive sites with experienced dive guides: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "port_fees",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027"
-          },
-          "amount": null,
-          "note": "late away from harbour- and sadly early return: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "carlton",
-      "name": "Carlton",
-      "boat": "Carlton",
-      "summary": "The Carlton liveaboard sails 7-day Red Sea itineraries to Ras Mohammed, Tiran, and St. John's, with 10 en suite cabins for up to 20 guests.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "note": "Airport Transfer"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": {
-            "amount": 40.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": {
-            "amount": 175.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2005 Year renovated 2026 Length 33 meters Beam 7 meters Top speed 12 knots Cruising speed 10 knots Engines Dosan Marine Max guests 20 Number of cabins 10 Number of bathrooms 10 Tenders 2 x 6: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 m 45 HP Water capacity 10 tons Fuel capacity 12 tons Freshwater maker 10 tons per day: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "cu",
-      "name": "CU",
-      "boat": "CU",
-      "summary": "Dive the Red Sea aboard the CU, a 38m (125-foot) liveaboard offering superb itineraries to iconic wrecks and reefs, professional service, and relaxed diving year-round.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": {
-            "amount": 400.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Nearly 1:1 Crew-to-Guest Ratio Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Laundry Service Library Outdoor Dining Audio & video entertainment Observation Deck Fishing Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2008 Year renovated 2018 Length 38 meters Deck area 456 sq: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 17 knots Engines 2 Manx750HP Max guests 28 Number of cabins 14 Number of bathrooms 16 Tenders 2x Yamaha *40 Water capacity 20 tons Fuel capacity 15 tons: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "From a Oceanic white tip: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/cu?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "destiny",
-      "name": "Destiny",
-      "boat": "Destiny",
-      "summary": "Destiny is a luxurious Red Sea liveaboard&nbsp;accommodating&nbsp;20 divers in 10 ensuite cabins. Eco-minded &agrave;-la-carte dining, spacious dive deck, sun deck, and iconic routes (BD/E, St. John&rsquo;s).",
-      "source_url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": {
-            "amount": 230.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 570.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Park and Port Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": {
-            "amount": 20.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 245.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Airport Transfer\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 180.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Tech diving Rebreather Support Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2023 Year renovated 2025 Length 37 meters Beam 8 meters Top speed 15 knots Cruising speed 12 knots Engines 2x MAN 900 HP Max guests 20 Number of cabins 10 Number of bathrooms 2 Tenders 2x Yamaha 85HP with ladders Water capacity 14 tons Fuel capacity 18 tons Freshwater maker 14 tons: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "discovery-ii",
-      "name": "Discovery II",
-      "boat": "Discovery II",
-      "summary": "Red Sea adventure awaits! Discovery II explores Egypt's iconic dive sites and untouched treasures",
-      "source_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 250.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "dune-longara",
-      "name": "DUNE Longara",
-      "boat": "DUNE Longara",
-      "summary": "Discover the DUNE Longara liveaboard in Egypt, a luxury Red Sea vessel for 30 guests offering stylish cabins, a Jacuzzi, fine dining, and unforgettable dive itineraries.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Environment Tax\" as a range"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 20.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "Hotel Transfer: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 210.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Dive deck Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "dune-silky",
-      "name": "DUNE Silky",
-      "boat": "DUNE Silky",
-      "summary": "DUNE Silky liveaboard is a modern, spacious yacht in the Red Sea, Egypt. With 13 twin en-suite and air-conditioned cabins for up to 26 guests, Alia offers dive itineraries to top Red Sea spots such as Daedalus, St, John&rsquo;s and Brothers.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Environment Tax\" as a range"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 20.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 210.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Laundry Service Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-          },
-          "amount": null,
-          "note": "we mentioned this upon reservation but upon arrival to the boat they had no idea: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "dune-titan",
-      "name": "DUNE Titan",
-      "boat": "DUNE Titan",
-      "summary": "Join the DUNE Titan for a budget-friendly Red Sea liveaboard. The 39m Titan offers year-round dive safaris to the best Egyptian dive sites, including the Ras Mohammed Marine Park, Straits of Tiran, St. Johns, Brothers, and Elphinstone.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Environment Tax\" as a range"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 20.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 210.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Tech diving Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-          },
-          "amount": null,
-          "note": "They are air-conditioned and feature a private shower and toilet: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "emperor-asmaa",
-      "name": "Emperor Asmaa",
-      "boat": "Emperor Asmaa",
-      "summary": "Emperor Asmaa offers true value for money while diving the Red Sea. 10 ensuite cabins to cater for 20 guests on board. Free nitrox, WiFi and wine with dinner.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": {
-            "amount": 120.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": {
-            "amount": 160.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": {
-            "amount": 599.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rebreather Support Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2003 Year renovated 2015 Length 30 meters Beam 7 meters Engines 2 x 440HP Mercedes Max guests 20 Number of cabins 9 Number of bathrooms 10 Tenders 2 x Zodiac 25 HP Water capacity 2 Aquaset x 5500 L / Day & storage Freshwater maker 5500 L / Day & storage: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "emperor-elite",
-      "name": "Emperor Elite",
-      "boat": "Emperor Elite",
-      "summary": "The Emperor Elite, winner of Best Liveaboard 2020 offers year-round diving to some of the best spots in the Red Sea. Free nitrox and WiFi are included.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": {
-            "amount": 120.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": {
-            "amount": 160.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": {
-            "amount": 599.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rebreather Support Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2006 Year renovated 2015 Length 38 meters Beam 8 meters Engines 2 x 764HP Caterpiller Max guests 26 Number of cabins 13 Number of bathrooms 14 Tenders 2 x Zodiacs Water capacity 11000 L / Day & storage Freshwater maker 15000 liters per day: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "emperor-superior",
-      "name": "Emperor Superior",
-      "boat": "Emperor Superior",
-      "summary": "The Emperor Superior is perfectly set up for photographers to enjoy week-long itineraries in the Red Sea. Many trips allow for 21+ dives per week.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": {
-            "amount": 120.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": {
-            "amount": 160.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": {
-            "amount": 599.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2004 Year renovated 2015 Length 37 meters Beam 8: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "eriny",
-      "name": "Eriny",
-      "boat": "Eriny",
-      "summary": "The Eriny is a liveaboard offering 10 air-conditioned ensuite cabins, top-notch facilities, and expertly curated Red Sea itineraries featuring sites like the Thistlegorm, Abu Nuhas, and Tiran Strait.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": {
-            "amount": 5.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "note": "Airport Transfer"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available DIN Adaptors Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2023 Year renovated Every year Length 38 meters Top speed 10 knots Cruising speed 9 knots Engines 2 Max guests 20 Number of cabins 10 Number of bathrooms 11 Tenders 2 Water capacity 10 tons Fuel capacity 11/12 tons: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "freedom-iii",
-      "name": "Freedom III",
-      "boat": "Freedom III",
-      "summary": "The Freedom III liveaboard explores the Northern Red Sea with 3 - 6 night itineraries. 9 En-suite cabins are on-board, each with AC, TV &amp; DVD, fridge &amp; safe. There are also 2 sun decks for relaxation.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": {
-            "amount": 55.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 90.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": {
-            "amount": 99.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 tonnes Fuel capacity 8 tonnes: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "freedom-iv",
-      "name": "Freedom IV",
-      "boat": "Freedom IV",
-      "summary": "The Freedom IV is a 28-meter/92-feet-long liveaboard based in Sharm El Sheikh, Egypt, taking 24 guests in&nbsp;11 air-conditioned cabins on diving safaris in the northern Red Sea, including Thitlegorm and Ras Mohammed.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 12.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 75.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck BBQ Area Available for Charter Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "ghazala-adventure",
-      "name": "Ghazala Adventure",
-      "boat": "Ghazala Adventure",
-      "summary": "Explore the Red Sea aboard the Ghazala Adventure, hosting 26 guests with air-conditioned cabins, gourmet buffets, free Nitrox, and diverse itineraries from wrecks to pristine reefs.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Boutique / Souvenir Shop Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 14 knots Cruising speed 12 knots Engines 2 Cummins KTA 38 Max guests 26 Number of cabins 14 Number of bathrooms 16 Tenders 2 RIBs with 115HP Yamaha each Water capacity 12 tons Fuel capacity 20 tons Freshwater maker 18000L / day: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "ghazala-explorer",
-      "name": "Ghazala Explorer",
-      "boat": "Ghazala Explorer",
-      "summary": "Ghazala Explorer liveaboard in the Egyptian Red Sea is a modern motor yacht with 12 ensuite cabins, taking up to 24 guests to top sites in the Red Sea. Visit Daedalus, St. Johns, Elphinstone, Ras Mohammed, or the Thistlegorm wreck.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "2 meters Top speed 13 knots Cruising speed 11 knots Engines 2 x MAN 1100 Hp Max guests 24 Number of cabins 13 Number of bathrooms 14 Tenders 2 Water capacity 12 tons Fuel capacity 20 tons Freshwater maker 2 * 7 tons each: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "golden-dolphin",
-      "name": "Golden Dolphin",
-      "boat": "Golden Dolphin",
-      "summary": "The MY Golden Dolphin liveaboard offers year-round diving to the best Red Sea dive sites, from the north to far south. 10 en-suite, air-conditioned cabins cater to 20 guests. Nitrox is available onboard.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 490.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2003 Year renovated 2007 Length 32m Beam 7: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "golden-dolphin-iv",
-      "name": "Golden Dolphin IV",
-      "boat": "Golden Dolphin IV",
-      "summary": "The Golden Dolphin IV is a 46mtr/151ft long liveaboard in Egypt taking guests to some of the most iconic dive sites in the Red Sea.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 490.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Local & International Crew Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "golden-imperial",
-      "name": "Golden Imperial",
-      "boat": "Golden Imperial",
-      "summary": "Luxury Red Sea diving aboard the Golden Imperial with 14 cabins, Nitrox, spacious decks, and routes to Brothers, Daedalus &amp; St. Johns.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 490.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Outdoor Dining Audio & video entertainment TV in cabins Observation Deck BBQ Area Available for Charter Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "gordon-reef",
-      "name": "Gordon Reef Liveaboard Diving",
-      "boat": "Gordon Reef Liveaboard Diving",
-      "summary": "With a host of large and small marine life, a Gordon Reef liveaboard has it all. The wreck of the Louilla, critters such as nudibranchs, shrimp, octopuses, a variety of eels and large schools of fish can be seen when diving on the reefs and, occasionally, oceanic whitetips and hammerheads sharks.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/gordon-reef?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/gordon-reef?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "grand-discovery",
-      "name": "Grand Discovery",
-      "boat": "Grand Discovery",
-      "summary": "Experience luxury diving in the Red Sea aboard MY Grand Discovery&mdash;24 cabins, Jacuzzi skydeck, full-service bar, and epic itineraries to Thistlegorm, Brothers, Daedalus, and beyond.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 250.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": {
-            "amount": 5.0,
-            "currency": "EUR"
-          },
-          "note": "Laundry / Pressing Services"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "hamata",
-      "name": "Hamata Liveaboard Diving",
-      "boat": "Hamata Liveaboard Diving",
-      "summary": "Hamata offers guests some of the newest dive areas in Egypt. Bright coral reefs, white-tipped reef sharks and pods of spinner dolphins make liveaboard diving here an unforgettable experience. The wrecks at Soraya have created beautiful self-contained ecosystems. It's also rapidly becoming a hotspot for kite-surfers.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/hamata?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hamata?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "hammerhead-ii",
-      "name": "Hammerhead II",
-      "boat": "Hammerhead II",
-      "summary": "Hammerhead II liveaboard operates in the Egyptian Red Sea. With 16 cabins catering for up to 32 guests. Cabins have a/c and some come with private en suite facilities. Itineraries visit well known Red Sea dive hotspots Brothers, St Johns and Daedalus",
-      "source_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Park and Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Airport Transfer: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 480.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 960.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Private Dive Guide\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Laundry / Pressing Services: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "The boat needs renovation of the rooms: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "iceberg",
-      "name": "Iceberg",
-      "boat": "Iceberg",
-      "summary": "The Iceberg is a liveaboard taking 8 guests on diving safaris in Egypt&rsquo;s Red Sea. Itineraries range from a single-day trip to week-long trips exploring the northern Red Sea&rsquo;s best dive sites.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": {
-            "amount": 140.0,
-            "currency": "EUR"
-          },
-          "note": "Port and Fuel Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": {
-            "amount": 55.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": {
-            "amount": 145.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 260.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Scuba Diving Courses\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "jackson-reef",
-      "name": "Jackson Reef Liveaboard Diving",
-      "boat": "Jackson Reef Liveaboard Diving",
-      "summary": "Jackson Reef liveaboard diving can be epitomised in one word: Sharks! Aside from the usual reef sharks, from June to September there is a large influx of scalloped hammerhead sharks, with occasional tiger and whale shark sightings. There are vast shoals of fish living in this colorful reef.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/jackson-reef?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jackson-reef?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "jp-marine",
-      "name": "JP Marine",
-      "boat": "JP Marine",
-      "summary": "MY JP Marine is a spacious liveaboard designed for the comfort of divers. 14 en-suite bathrooms, 2 sundecks, lounge, dining room &amp; bar. The JP Marine yacht explores the best dive sites of the Red Sea.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": {
-            "amount": 145.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 215.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 125.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Internet En-Suite bathrooms Aircon Cabins Warm Water Showers Air Conditioned saloon Sun Deck Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "lady-m",
-      "name": "Lady M",
-      "boat": "Lady M",
-      "summary": "Experience Red Sea liveaboard diving aboard the Lady M, offering comfort and access to iconic sites like Brothers, Daedalus, Elphinstone, Fury Shoals, and St. John&rsquo;s.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": {
-            "amount": 40.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 120.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": {
-            "amount": 10.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": {
-            "amount": 25.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": {
-            "amount": 95.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Private Dive Guide\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Budget Friendly Cruise Family Friendly Cruise Non-Smoking Rooms Charging stations Indoor Saloon Audio & video entertainment Observation Deck Available for Charter Snorkeling Equipment Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "marselia-star",
-      "name": "Marselia Star",
-      "boat": "Marselia Star",
-      "summary": "Sail the Red Sea aboard Marselia Star, a modern 12-cabin liveaboard with diver lift, tech diving support, and itineraries to Egypt&rsquo;s top reefs, wrecks, and shark sites.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 220.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": {
-            "amount": 155.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Outdoor Dining Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Leisure Deck Daily housekeeping Bar Dedicated Local Crew Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "new-sambo",
-      "name": "New Sambo",
-      "boat": "New Sambo",
-      "summary": "The New Sambo liveaboard offers a Red Sea diving experience with daily happy hours, onboard yoga classes, and a unique outdoor BBQ on a spacious sun terrace.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": {
-            "amount": 25.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 60.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": {
-            "amount": 55.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 75.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Hotel Transfer\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": {
-            "amount": 135.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 570.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Scuba Diving Courses\" as a range"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Naturalist Guide En-Suite bathrooms Aircon Cabins Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck BBQ Area Available for Charter Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2020 Year renovated 2024 Length 30 Top speed 18 km/hrs Cruising speed 13 km/hrs Engines 10 cylinder Max guests 20 Number of cabins 10 Number of bathrooms 12 Water capacity 11 tons Fuel capacity 6 tons: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "oceanix",
-      "name": "Oceanix",
-      "boat": "Oceanix",
-      "summary": "Explore Egypt&rsquo;s Red Sea aboard Oceanix, a modern 24-guest liveaboard offering en-suite cabins, spacious sun decks, Nitrox, and thrilling dive safaris.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 75.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 75.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 40.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 160.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck Hair Dryer in Cabin BBQ Area Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "odyssey",
-      "name": "MY Odyssey Liveaboard",
-      "boat": "MY Odyssey Liveaboard",
-      "summary": "Join the Odyssey yacht for an exciting Red Sea dive safari. Bright &amp; colourful she caters for up to 26 guests in 13 en-suite modern cabins, dining room, indoor &amp; outdoor lounge &amp; sundeck with hot tub.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": {
-            "amount": 130.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 250.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": {
-            "amount": 470.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck Available for Charter Separate Rinse for u/w Camera Outside Showers Leisure Deck Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2012 Year renovated 2016 Length 40 meters Beam 8 meters Top speed 15 Knots Cruising speed 10 Knots Engines 2 X Man-V12-Biturbo-1140 HP Max guests 26 Number of cabins 14 Number of bathrooms 13 Tenders 2x Yamaha 85cv Water capacity 7 000 liters Fuel capacity 15 000 liters Freshwater maker 20 000 liters per day: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "queen-sherry",
-      "name": "Queen Sherry",
-      "boat": "Queen Sherry",
-      "summary": "Explore the Red Sea aboard the Queen Sherry liveaboard, accommodating 24 guests in 12 cabins. Dive iconic sites and enjoy unique dolphin encounters with an onboard specialist.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": {
-            "amount": 145.0,
-            "currency": "EUR"
-          },
-          "note": "Port and Fuel Fees"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 125.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Family Friendly Cruise Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Library Outdoor Dining Audio & video entertainment Observation Deck Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "red-sea-aggressor-ii",
-      "name": "Red Sea Aggressor II",
-      "boat": "Red Sea Aggressor II",
-      "summary": "Egypt's finest liveaboard! Red Sea Aggressor II delivers stunning Red Sea reefs, wrecks and thrilling dives",
-      "source_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "USD"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "USD"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "Recommended for Dive Guide: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-          },
-          "amount": null,
-          "note": "with a private head and shower: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "red-sea-aggressor-iv",
-      "name": "Red Sea Aggressor IV",
-      "boat": "Red Sea Aggressor IV",
-      "summary": "The Red Sea Aggressor IV is a 43.5 meters/142.7 feet long liveaboard sailing from Port Ghalib, in Egypt&rsquo;s Red Sea, taking 26 passengers in 13 cabins to the best dive sites in the Southern Red Sea.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "USD"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 105.0,
-            "currency": "USD"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "USD"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 105.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "Also Recommended for Friendliness and helpfulness of the crew and dive guides: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Queen bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        },
-        {
-          "code": "single_supplement",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-          },
-          "amount": null,
-          "note": "NOTE: This stateroom is for couples and single supplements only: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "red-sea-aggressor-v",
-      "name": "Red Sea Aggressor V",
-      "boat": "Red Sea Aggressor V",
-      "summary": "The Red Sea Aggressor V is a liveaboard offering comfortable accommodations, top-tier amenities, and diving adventures in Egypt&rsquo;s southern Red Sea.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "USD"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 105.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 205.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "USD"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 40.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 60.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Airport Transfer\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 250.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "dive guides and captain: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "0 ft&#xB2; Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        },
-        {
-          "code": "single_supplement",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-          },
-          "amount": null,
-          "note": "This stateroom is for couples and single supplement only: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "red-sea-blue-force-2",
-      "name": "Red Sea Blue Force 2",
-      "boat": "Red Sea Blue Force 2",
-      "summary": "The Red Sea Blue Force 2 offers itineraries that cover the best of the Red Sea dive sites. Catering to up to 18 guests she has 10 en-suite cabins with air-conditioning, lounge, dining room &amp; sun deck.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 120.0,
-            "currency": "EUR"
-          },
-          "note": "Park and Port Fees"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": {
-            "amount": 160.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "Red Sea Blue Force 2 Red Sea Blue Force 2 Red Sea Blue Force 2 Observation deck - Red Sea Blue Force 2 Sun Deck - Red Sea Blue Force 2 Sun Deck - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Outdoor Lounge - Red Sea Blue Force 2 Bar Area - Red Sea Blue Force 2 Indoor Saloon - Red Sea Blue Force 2 Indoor Saloon - Red Sea Blue Force 2 Dining Room - Red Sea Blue Force 2 Lower Deck Cabin - Red Sea Blue Force 2 Lower Deck Cabin - Red Sea Blue Force 2 Upper Deck Cabin - Red Sea Blue Force 2: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "red-sea-explorer",
-      "name": "Red Sea Explorer",
-      "boat": "Red Sea Explorer",
-      "summary": "Sail the Red Sea on MY Red Sea Explorer, a 43m (141ft) liveaboard with 12 cabins for 24 guests, offering up to 4 dives daily, Nitrox, and departures from Hurghada or Port Ghalib.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 280.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 340.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 25.0,
-            "currency": "EUR"
-          },
-          "note": "Airport Transfer"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 145.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment TV in cabins Observation Deck Hair Dryer in Cabin Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "reef-voyager",
-      "name": "Reef Voyager",
-      "boat": "Reef Voyager",
-      "summary": "Explore the Red Sea aboard Reef Voyager, a modern liveaboard with top diving facilities, and unforgettable wreck and reef itineraries.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Park and Port Fees\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": {
-            "amount": 45.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": {
-            "amount": 88.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2023 Length 30 meters Beam 8 meters Top speed 15 knots Cruising speed 13 knots Engines 2x 800 Hp Scania Max guests 22 Number of cabins 11 Number of bathrooms 2 Tenders 2x 40 Hp Yamaha Water capacity 12000 liters Fuel capacity 15000 liters Freshwater maker 24000 liters per day: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "rocky",
-      "name": "Rocky Liveaboard Diving",
-      "boat": "Rocky Liveaboard Diving",
-      "summary": "Rocky Island liveaboards have almost everything Red Sea diving has to offer. Huge, shallow, colorful coral reefs make for stunning photographs. Whilst doing swim-throughs and drift dives, be sure to look out for shoals of striped grunts, hunting barracuda, hammerheads and oceanic whitetip sharks.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/rocky?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/rocky?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "royal-evolution",
-      "name": "Royal Evolution",
-      "boat": "Royal Evolution",
-      "summary": "The Royal Evolution is a 39-meter liveaboard accommodating 24 passengers in 12 air-conditioned cabins, comprising 2 double suites, 2 twin suites, and 8 standard suite cabins, all with private bathrooms with hot showers.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": {
-            "amount": 170.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 325.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Fuel Surcharge\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 260.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Park and Port Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": {
-            "amount": 0.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Airport Transfer\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 90.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment TV in cabins Observation Deck BBQ Area Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "dive guides and captain - a pleasant: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "safy-mar",
-      "name": "Safy Mar",
-      "boat": "Safy Mar",
-      "summary": "Dive the Egyptian Red Sea aboard Safy Mar, a 2024-built liveaboard for 34 divers, with routes to St. John's, Fury Shoal, the Brothers and Tiran.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 20.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Airport Transfer\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 165.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Safe Box in Cabin Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "salem-express",
-      "name": "Salem Express Liveaboard Diving",
-      "boat": "Salem Express Liveaboard Diving",
-      "summary": "After running aground in 1991 carrying pilgrims back from Mecca, the Salem Express sank and took the lives of over half of those on board. A liveaboard here is more of a historical dive than one concerned with marine life, with the vehicles and packed luggage of the ill-fated passengers still clearly on show.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/salem-express?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/salem-express?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "sea-friend",
-      "name": "Sea Friend",
-      "boat": "Sea Friend",
-      "summary": "The Sea Friend liveaboard departs directly from Hamata to offer less time for traveling and more time for exploring the stunning reefs of the southern Red Sea. Each cabin features en-suite bathrooms, AC, and storage space.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 450.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Laundry / Pressing Services: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available DIN Adaptors Dive deck Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-          },
-          "amount": null,
-          "note": "air conditioning plus a small private bathroom with shower and toilet: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "sea-serpent",
-      "name": "Sea Serpent",
-      "boat": "Sea Serpent",
-      "summary": "The unique hull design of the 34m MY Sea Serpent ensures the smoothest voyage to&nbsp;the best&nbsp;Red Sea diving destinations, including the spectacular Brother Islands, Elphinstone Reef and Daedalus.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
           },
           "amount": {
             "amount": 100.0,
@@ -10111,686 +1341,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": {
-            "amount": 175.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 11 knots Cruising speed 9 knots Engines 2 X 1150 HP Man Max guests 22 Number of cabins 11 Number of bathrooms 13 Tenders 2 X Yamaha 65HP Water capacity 11 Tons Fuel capacity 9 Tons Freshwater maker 18000L / Day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "sea-serpent-excellence",
-      "name": "Sea Serpent Excellence",
-      "boat": "Sea Serpent Excellence",
-      "summary": "Itineraries aboard the MY Sea Serpent Excellence include the famous sites of the Red Sea, such as the Tiran Strait, the Brother Islands, Daedalus, and Elphinstone. The Sea Serpent Excellence is fitted with 12 en-suite cabins.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": {
-            "amount": 175.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2008 Year renovated 2020 Length 36 meters Beam 8 meters Top speed 13 knots Cruising speed 10 knots Engines 2 X 1100 HP Man Max guests 24 Number of cabins 12 Number of bathrooms 13 Tenders 2 X Yamaha 65 HP Water capacity 14 Tons Fuel capacity 11 Tons Freshwater maker 8000L/day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "sea-serpent-grand",
-      "name": "Sea Serpent Grand",
-      "boat": "Sea Serpent Grand",
-      "summary": "Exploring the wreck of the SS Thistlegorm is about as comfortable as it can possibly get while sailing aboard the huge 45m MY Sea Serpent Grand. Her 14 luxury en-suite cabins ensure maximum comfort.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": {
-            "amount": 175.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Observation Deck Hair Dryer in Cabin Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 12 knots Cruising speed 10 knots Engines 2 x 720 HP CAT Max guests 28 Number of cabins 14 Number of bathrooms 16 Tenders 2 X 65 HP Yamaha Water capacity 18 Tons Fuel capacity 11 Tons Freshwater maker 22000L / Day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "serenity",
-      "name": "Serenity",
-      "boat": "Serenity",
-      "summary": "The Serenity is a 33-meter/108-foot liveaboard taking 24 guests on diving trips through Egypt&rsquo;s Red Sea in 12 spacious air-conditioned cabins with ensuite facilities.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 220.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Visas and Fees"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": {
-            "amount": 35.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck Available for Charter Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "shark-and-yolanda",
-      "name": "Shark and Yolanda Reefs Liveaboard Diving",
-      "boat": "Shark and Yolanda Reefs Liveaboard Diving",
-      "summary": "Shark and Yolanda Reef liveaboard diving offers guests a stunning reef teeming with critters and surrounded by huge shoals of fish such as barracuda, jackfish and batfish. The wreck of the Yolanda has its cargo strewn all over the sea floor which includes bathtubs, toilets and even an old BMW.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/shark-and-yolanda?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/shark-and-yolanda?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "sinaistar",
-      "name": "Sinaistar",
-      "boat": "Sinaistar",
-      "summary": "Dive the Red Sea aboard the Sinaistar&mdash;13 cabins, spacious dive deck, sun deck, and weekly trips from Hurghada.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": {
-            "amount": 190.0,
-            "currency": "EUR"
-          },
-          "note": "Port and Fuel Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
           },
           "amount": {
             "amount": 220.0,
@@ -10807,7 +1358,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
           },
           "amount": {
             "amount": 450.0,
@@ -10823,94 +1374,24 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Stand Up Paddleboard Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
         }
       ]
     },
     {
-      "id": "sindalahs",
-      "name": "Sindalahs",
-      "boat": "Sindalahs",
-      "summary": "Explore the Red Sea aboard Sindalahs, a liveaboard offering 7-day dive trips to iconic sites like Brothers, Daedalus, Elphinstone, and Saint John. Gourmet cuisine and top-tier amenities for 26 guests.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027",
+      "id": "alsuraya",
+      "name": "ALSURAYA",
+      "boat": "ALSURAYA",
+      "summary": "The ALSURAYA is a Red Sea liveaboard offering spacious cabins, top-tier amenities, and unforgettable diving and kiteboarding adventures across world-class sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
       },
       "fees": [
         {
@@ -10922,14 +1403,14 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
           },
           "amount": {
             "amount": 150.0,
             "currency": "EUR"
           },
           "amount_max": {
-            "amount": 200.0,
+            "amount": 250.0,
             "currency": "EUR"
           },
           "note": "Operator quotes \"National Park Fees\" as a range"
@@ -10943,1094 +1424,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": {
-            "amount": 20.0,
-            "currency": "EUR"
-          },
-          "note": "Airport Transfer"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Nearly 1:1 Crew-to-Guest Ratio Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Laundry Service Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2024 Year renovated 2025 Length 38 meters Beam 8: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "4 meters Top speed 14 knots Cruising speed 11 knots Engines Doosan v222TIM 788 HP EACH 2100 RPM Max guests 26 Number of cabins 14 Number of bathrooms 17 Tenders Yamaha 115 Water capacity 26500 liters Fuel capacity 28510 liters: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "snefro-love",
-      "name": "Snefro Love",
-      "boat": "Snefro Love",
-      "summary": "The Snefro Love liveaboard departs from Sharm el Sheikh for week-long dive safaris in the Straits of Tiran. She caters for 20 guests in 10 cabins.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": {
-            "amount": 65.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 130.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": {
-            "amount": 110.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 245.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Rental Gear\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2010 Year renovated 2023 Length 37m Beam 9m Engines 2 x 460 HP G: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "There should be 10 stars for the dive guides and staff: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "snefro-pearl",
-      "name": "Snefro Pearl",
-      "boat": "Snefro Pearl",
-      "summary": "The Snefro Pearl liveaboard is perfect for small groups of 12 divers. Itineraries are 4-8 days. Explore Ras Mohammed, The Straits of Tiran and the Thistlegorm during a Red Sea dive safari.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 65.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 130.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Park and Port Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": {
-            "amount": 110.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 245.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Rental Gear\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2012 Year renovated 2025 Length 29m Beam 7m Engines 2 x 340 HP G: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "Thanks to the crew for a wonderful experience! Recommended for Dive guide and crew: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "snefro-target",
-      "name": "Snefro Target",
-      "boat": "Snefro Target",
-      "summary": "Join the Snefro Target for fantastic Northern Red Sea diving. Explore Shark &amp; Yolanda, the Thistlegorm as well as the famous reefs in the Straits of Tiran.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "fuel_surcharge",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": {
-            "amount": 65.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 130.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port and Fuel Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Gratuities\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": {
-            "amount": 185.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": {
-            "amount": 110.0,
-            "currency": "USD"
-          },
-          "amount_max": {
-            "amount": 245.0,
-            "currency": "USD"
-          },
-          "note": "Operator quotes \"Rental Gear\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2010 Year renovated 2023 Length 37m Beam 9m Engines 2 x 460 HP G: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "dive guides and great crew 30 Oct: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "south-moon-1",
-      "name": "South Moon 1",
-      "boat": "South Moon 1",
-      "summary": "The South Moon 1 is a 30m Red Sea liveaboard offering comfortable cabins, excellent dive facilities, international cuisine, and iconic itineraries to the region&rsquo;s best reefs and wrecks.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 140.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": {
-            "amount": 30.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 50.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Port Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": {
-            "amount": 90.0,
-            "currency": "EUR"
-          },
-          "note": "Gratuities"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": {
-            "amount": 225.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "Private Dive Guide: listed with no price"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Audio & video entertainment Observation Deck Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2024 Length 30 meters Beam 8 meters Top speed 13 knots Engines 2 x 1150 hp MAN Max guests 24 Number of cabins 11 Number of bathrooms 12 Tenders 2x ZODIAC 6m Yamaha engines 55 hp &#x2B; 40 hp engine Water capacity 10000 liters Fuel capacity 10000 liters Freshwater maker 10 tones per day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "ss-glorious-miss-nouran",
-      "name": "SS Glorious Miss Nouran",
-      "boat": "SS Glorious Miss Nouran",
-      "summary": "The Sea Serpent Glorious Miss Nouran liveaboard operates in the Egyptian Red Sea and has 13 ensuite cabins for up to 26 guests. Itineraries visit favorite sites such as Daedalus, Brothers, Elphinstone, and the SS Thistlegorm.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": {
-            "amount": 175.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Top speed 12 knots Cruising speed 10 knots Engines 2x 1100 HP MAN Max guests 26 Number of cabins 13 Number of bathrooms 15 Tenders 2x Yamaha 25HP Water capacity 11 tons Fuel capacity 9 tons Freshwater maker 18000 Liter/day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "port_fees",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-          },
-          "amount": null,
-          "note": "We had to pay our rentals and port fees and the price is listed but if you pay with a credit card: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "ss-serena-dreams",
-      "name": "SS Serena Dreams",
-      "boat": "SS Serena Dreams",
-      "summary": "Join the fantastic Sea Serpent Serena Dreams for a Red Sea diving liveaboard to remember. Built by divers for divers to offer unforgettable diving in the Red Sea. 9 en-suite guest cabins accommodate 18 passengers.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "National Park Fees"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
           },
           "amount": {
             "amount": 100.0,
@@ -12047,10 +1441,10 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
           },
           "amount": {
-            "amount": 175.0,
+            "amount": 220.0,
             "currency": "EUR"
           },
           "note": "Nitrox Course"
@@ -12064,7 +1458,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
           },
           "amount": {
             "amount": 450.0,
@@ -12080,98 +1474,28 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Boutique / Souvenir Shop Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Library Outdoor Dining Audio & video entertainment Smart Voyager accreditation Observation Deck Safe Box in Cabin BBQ Area Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2007 Year renovated 2020 Length 33 meters Beam 7 meters Top speed 11 knots Cruising speed 9 knots Engines 2x 600 HP CAT Max guests 18 Number of cabins 9 Number of bathrooms 11 Tenders 2x Yamaha 45HP Water capacity 11 tons Fuel capacity 9 tons Freshwater maker 10000L/day: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
         }
       ]
     },
     {
-      "id": "star-jet",
-      "name": "Star Jet",
-      "boat": "Star Jet",
-      "summary": "Experience the Red Sea aboard Star Jet, a liveaboard with 15 cabins, sundecks, gourmet cuisine, and itineraries to Brothers, Daedalus, Ras Mohammed, and the Thistlegorm.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027",
+      "id": "alsuraya",
+      "name": "ALSURAYA",
+      "boat": "ALSURAYA",
+      "summary": "The ALSURAYA is a Red Sea liveaboard offering spacious cabins, top-tier amenities, and unforgettable diving and kiteboarding adventures across world-class sites.",
+      "source_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
       },
       "fees": [
         {
-          "code": "port_fees",
+          "code": "marine_park",
           "tier": "mandatory",
           "basis": "per_trip",
           "included": false,
@@ -12179,292 +1503,19 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Park and Port Fees"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": {
-            "amount": 17.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 90.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Airport Transfer\" as a range"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
           },
           "amount": {
             "amount": 150.0,
             "currency": "EUR"
           },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": {
-            "amount": 450.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Smart Voyager accreditation Observation Deck Hair Dryer in Cabin Available for Charter Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar Dedicated Local Crew Naturalist Guide: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "9 meters Top speed 25 knots Cruising speed 15 knots Engines 2x Mercedes Max guests 28 Number of cabins 14 Number of bathrooms 17 Tenders 2x Water capacity 18000 liters Fuel capacity 16000 liters Freshwater maker 15000 liters: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "sunlight",
-      "name": "Sunlight",
-      "boat": "Sunlight",
-      "summary": "Having undergone a complete renovation in 2019, the MY Sunlight is ready to show off the best of the Red Sea. A choice of routes is available including North, South and Deep South. 10 air-conditioned cabins with ensuite bathrooms cater to 20 guests.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
           "amount_max": {
-            "amount": 200.0,
+            "amount": 250.0,
             "currency": "EUR"
           },
           "note": "Operator quotes \"National Park Fees\" as a range"
         },
         {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Laundry Service Library Audio & video entertainment Observation Deck Available for Charter Local & International Crew Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 1999 Year renovated 2019 Length 34 Beam 7 Top speed 15 knots Cruising speed 13 knots Engines 2x Mercedes MTU Marine 650HP Max guests 20 Number of cabins 10 Number of bathrooms 12 Tenders 2 Water capacity 10 Fuel capacity 10 Freshwater maker 2x 55 tons p/d: listed with no price"
-        },
-        {
           "code": "gratuities",
           "tier": "customary",
           "basis": "per_trip",
@@ -12473,325 +1524,15 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "we were able to help ourselves multiple times: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "The dive guides were awesome We saw and swam several times with dolphins: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "the dives of course: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "sunshine",
-      "name": "Sunshine",
-      "boat": "Sunshine",
-      "summary": "The M/Y Sunshine yacht offers year-round dive safaris in the Red Sea. 10 en-suite cabins with AC cater to 20 guests. Itineraries are 5-7 nights long and explore the northern and southern routes.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
           },
           "amount": {
             "amount": 100.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "port_fees",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": {
-            "amount": 70.0,
-            "currency": "EUR"
-          },
-          "note": "Port Fees"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": {
-            "amount": 50.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Seaview Cabins Naturalist Itineraries Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Audio & video entertainment Observation Deck Available for Charter Local & International Crew Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox DIN Adaptors Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built 2005 Year renovated 2013 Length 31 Beam 75 Top speed 12 knots Cruising speed 10 knots Engines 2xMercedes 575HP Max guests 20 Number of cabins 10 Number of bathrooms 11 Tenders 2 Water capacity 17 tons Fuel capacity 14 tons Freshwater maker 2x 25 tons p/d: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "T The Au Co Tip Top II Tip Top IV Treasure of Galapagos Tribute: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "tala",
-      "name": "Tala",
-      "boat": "Tala",
-      "summary": "Join the MV Tala liveaboard for a Red Sea diving safari. Exploring some of the best dive areas in the region such as Brothers, Daedalus, Elphinstone and the SS Thistlegorm, she is perfectly set up for tech divers with a range of mixes and tanks.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": {
-            "amount": 200.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 320.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Environment Tax\" as a range"
-        },
-        {
-          "code": "dive_insurance",
-          "tier": "conditional",
-          "basis": "per_day",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": {
-            "amount": 6.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
             "currency": "EUR"
           },
           "note": "Gratuities"
         },
         {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": {
-            "amount": 60.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 135.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox\" as a range"
-        },
-        {
           "code": "course",
           "tier": "optional",
           "basis": "per_trip",
@@ -12800,160 +1541,10 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
           },
           "amount": {
-            "amount": 207.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 283.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Nitrox Course\" as a range"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": {
-            "amount": 350.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "25 M Top speed 14 knots Cruising speed 12-14 Knots Engines 2 x 580 diesel caterpillars Max guests 22 Number of cabins 11 Fuel capacity 5000 Liters &#x2B; 2 Daily tanks Freshwater maker 16 000 Liters: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-          },
-          "amount": null,
-          "note": "1 Double bed Aircon with control Ensuite Bathroom Max 2 guests Private cabin: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "unity",
-      "name": "Unity",
-      "boat": "Unity",
-      "summary": "Discover the Unity Liveaboard in the Red Sea, offering 13 ensuite cabins for 24 guests. Enjoy unforgettable dive trips to iconic reefs, wrecks, and shark hotspots.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": {
-            "amount": 225.0,
+            "amount": 220.0,
             "currency": "EUR"
           },
           "note": "Nitrox Course"
@@ -12967,387 +1558,7 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": {
-            "amount": 575.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Air Conditioned saloon Sun Deck Camera Station Budget Friendly Cruise Family Friendly Cruise Seaview Cabins Non-Smoking Rooms Custom built for diving Charging stations Indoor Saloon Outdoor Dining Observation Deck Safe Box in Cabin Available for Charter Local & International Crew Snorkeling Equipment Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Free Nitrox Shaded Diving Area DIN Adaptors Rinse Hoses Dive deck Tenders for diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "2 meters Top speed 9 knots Cruising speed 8 knots Engines 2 x 420 HP Mann Max guests 24 Number of cabins 13 Number of bathrooms 15 Tenders 1 x Yamaha 40 Hp 1 x25 HP Water capacity 10000 liters Fuel capacity 10 tons Freshwater maker 5000 liters per day: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "vita-xplorer",
-      "name": "Vita Xplorer",
-      "boat": "Vita Xplorer",
-      "summary": "Explore some of the best Red Sea dive sites aboard the Vita Xplorer. Dive the Ras Mohammed Marine Park, Thistlegorm, &amp; Abu Nuhas Wrecks, as well as Elphinstone, Brothers, &amp; Daedalus Reef.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "environment_tax",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 150.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Environment Tax\" as a range"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 75.0,
-            "currency": "EUR"
-          },
-          "note": "Nitrox Course"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 500.0,
-            "currency": "EUR"
-          }
-        },
-        {
-          "code": "gear_rental",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": {
-            "amount": 80.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 100.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"Rental Gear\" as a range"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "Year built May 2006 Year renovated April 2024 Length 38 70 m Beam 8 45 m Cruising speed 12 knots Engines &#x9;2 Cummins KTA19-M4 Heavy Duty &#xE0; 700 HP Number of cabins 12 Water capacity 20 tonnes Fuel capacity 20 tonnes Freshwater maker 20 t &#x2B; 2 x preparation 4 t per day: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "amazing crew and awesome dives! A Stunning Vessel and an Unforgettable Dive Experience&#xA;The boat is a true beauty&#x2014;fully renovated in 2024: listed with no price"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "there are closets for all your extras&#x2014;because we all know dive gear tends to multiply: listed with no price"
-        },
-        {
-          "code": "marine_park",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "K Koh Tachai Komodo Kimud Shoal Koror Keith Tibbetts Komodo National Park Koh Bon King Cruiser Wreck Kona Kimbe Bay Kapalai Kupang Kaimana Koon Island Kwajalein: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        }
-      ]
-    },
-    {
-      "id": "woodhouse-reef",
-      "name": "Woodhouse Reef Liveaboard Diving",
-      "boat": "Woodhouse Reef Liveaboard Diving",
-      "summary": "Woodhouse Reef being nearly a mile long, liveaboards here specialise in drift diving, especially in the aptly named Washing Machine. This reef also offers a sandy-bottomed canyon full of colorful corals and macro life. A large variety of sharks, rays and turtles take respite from the current here.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/woodhouse-reef?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/woodhouse-reef?m=5/2027"
-      },
-      "fees": []
-    },
-    {
-      "id": "yachtiano",
-      "name": "Yachtiano",
-      "boat": "Yachtiano",
-      "summary": "The Yachtiano is a 45.5-meter/149-foot liveaboard that accommodates 34 passengers for diving in the Red Sea. It offers exclusive itineraries full of wrecks, walls, coral gardens, and marine life.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-      },
-      "fees": [
-        {
-          "code": "marine_park",
-          "tier": "mandatory",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": {
-            "amount": 275.0,
-            "currency": "EUR"
-          },
-          "amount_max": {
-            "amount": 300.0,
-            "currency": "EUR"
-          },
-          "note": "Operator quotes \"National Park Fees\" as a range"
-        },
-        {
-          "code": "gratuities",
-          "tier": "customary",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "Gratuities: listed with no price"
-        },
-        {
-          "code": "course",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "Nitrox Course: listed with no price"
-        },
-        {
-          "code": "private_guide",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
           },
           "amount": {
             "amount": 450.0,
@@ -13363,110 +1574,12 @@
             "kind": "scraped",
             "source_id": "liveaboard.com",
             "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
+            "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
           },
           "amount": null,
           "note": "Rental Gear: listed with no price"
-        },
-        {
-          "code": "airport_transfer",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "Pay by bank transfer or online with: listed with no price"
-        },
-        {
-          "code": "laundry",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "Friendly Warm Water Showers Massage Air Conditioned saloon Sun Deck Rooms with Balcony Water Ski Wakeboarding Boutique / Souvenir Shop Nearly 1:1 Crew-to-Guest Ratio Seaview Cabins Naturalist Itineraries Paid Internet Non-Smoking Rooms Camera room Custom built for diving Charging stations Indoor Saloon Laundry Service Library Outdoor Dining Audio & video entertainment Observation Deck Hair Dryer in Cabin Safe Box in Cabin BBQ Area Local & International Crew Separate Rinse for u/w Camera Outside Showers Leisure Deck Daily housekeeping Bar: listed with no price"
-        },
-        {
-          "code": "nitrox",
-          "tier": "conditional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "] [&>*]:mx-3 -mx-3\"> Nitrox available Free Nitrox Shaded Diving Area Sidemount diving &#x2013; Single Tank Only DIN Adaptors Tech diving Rebreather Support Rinse Hoses Dive deck Tenders for diving Sidemount Diving: listed with no price"
-        },
-        {
-          "code": "fuel_surcharge",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "5 meters Deck area 9 meters Top speed 20 knots Cruising speed 17 knots Engines 2x MAN 12 cylinder with 1250 hp Max guests 34 Number of cabins 17 Number of bathrooms 21 Water capacity 16 tons Fuel capacity 12 tons: listed with no price"
-        },
-        {
-          "code": "visa",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "V Visayas Viti Levu Vicente Vaavu Atoll: listed with no price"
-        },
-        {
-          "code": "tax_vat",
-          "tier": "optional",
-          "basis": "per_trip",
-          "included": false,
-          "provenance": {
-            "kind": "scraped",
-            "source_id": "liveaboard.com",
-            "retrieved": "2026-08-27",
-            "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-          },
-          "amount": null,
-          "note": "each featuring air-conditioning and a private en-suite bathroom: listed with no price"
         }
       ]
-    },
-    {
-      "id": "zabargad",
-      "name": "Zabargad Liveaboard Diving",
-      "boat": "Zabargad Liveaboard Diving",
-      "summary": "Zabargad liveaboards offer guests the chance to go diving on a wreck of an old Russian spy ship in just 24m of calm water. Penetrate the engine room and bridge to discover hoards of glassfish. Octopus, squid, eels, rays, turtles, oceanic whitetips, hammerheads and reef sharks can be spotted too.",
-      "source_url": "https://www.liveaboard.com/diving/egypt/zabargad?m=5/2027",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/zabargad?m=5/2027"
-      },
-      "fees": []
     }
   ],
   "departures": [
@@ -13548,6 +1661,46 @@
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
         "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=5/2027"
+      }
+    },
+    {
+      "id": "alia-soul-2027-06-02-0",
+      "boat_slug": "alia-soul",
+      "name": " Marine Park North: Brothers - Daedalus & Elphinstone (Port Ghalib - Safaga/Soma Bay)",
+      "start": "2027-06-02",
+      "end": "2027-06-09",
+      "price": {
+        "amount": 1923.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=6/2027"
+      }
+    },
+    {
+      "id": "alia-soul-2027-08-04-0",
+      "boat_slug": "alia-soul",
+      "name": " Marine Park North: Brothers - Daedalus & Elphinstone (Port Ghalib - Safaga/Soma Bay)",
+      "start": "2027-08-04",
+      "end": "2027-08-11",
+      "price": {
+        "amount": 1923.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alia-soul?m=8/2027"
       }
     },
     {
@@ -13651,6 +1804,266 @@
       }
     },
     {
+      "id": "all-star-ghani-2027-06-07-0",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Brothers (Hurghada - Hurghada)",
+      "start": "2027-06-07",
+      "end": "2027-06-14",
+      "price": {
+        "amount": 1320.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-06-14-1",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Brothers (Hurghada - Hurghada)",
+      "start": "2027-06-14",
+      "end": "2027-06-21",
+      "price": {
+        "amount": 1320.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-06-21-2",
+      "boat_slug": "all-star-ghani",
+      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-06-21",
+      "end": "2027-06-28",
+      "price": {
+        "amount": 1385.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-06-28-3",
+      "boat_slug": "all-star-ghani",
+      "name": " North (Hurghada - Hurghada)",
+      "start": "2027-06-28",
+      "end": "2027-07-05",
+      "price": {
+        "amount": 1260.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-07-05-0",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Tiran (Hurghada - Hurghada)",
+      "start": "2027-07-05",
+      "end": "2027-07-12",
+      "price": {
+        "amount": 1385.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-07-12-1",
+      "boat_slug": "all-star-ghani",
+      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-07-12",
+      "end": "2027-07-19",
+      "price": {
+        "amount": 1385.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-07-19-2",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Brothers (Hurghada - Hurghada)",
+      "start": "2027-07-19",
+      "end": "2027-07-26",
+      "price": {
+        "amount": 1585.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-07-26-3",
+      "boat_slug": "all-star-ghani",
+      "name": " North (Hurghada - Hurghada)",
+      "start": "2027-07-26",
+      "end": "2027-08-02",
+      "price": {
+        "amount": 1985.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-08-02-0",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Tiran (Hurghada - Hurghada)",
+      "start": "2027-08-02",
+      "end": "2027-08-09",
+      "price": {
+        "amount": 1985.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-08-09-1",
+      "boat_slug": "all-star-ghani",
+      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-08-09",
+      "end": "2027-08-16",
+      "price": {
+        "amount": 1585.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-08-16-2",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Tiran (Hurghada - Hurghada)",
+      "start": "2027-08-16",
+      "end": "2027-08-23",
+      "price": {
+        "amount": 1260.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-08-23-3",
+      "boat_slug": "all-star-ghani",
+      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-08-23",
+      "end": "2027-08-30",
+      "price": {
+        "amount": 1385.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-ghani-2027-08-30-4",
+      "boat_slug": "all-star-ghani",
+      "name": " North & Tiran (Hurghada - Hurghada)",
+      "start": "2027-08-30",
+      "end": "2027-09-06",
+      "price": {
+        "amount": 1260.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-ghani?m=8/2027"
+      }
+    },
+    {
       "id": "all-star-red-sea-2027-05-03-0",
       "boat_slug": "all-star-red-sea",
       "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
@@ -13748,6 +2161,226 @@
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
         "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=5/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-06-07-0",
+      "boat_slug": "all-star-red-sea",
+      "name": " Daedalus & St. John's (Port Ghalib - Port Ghalib)",
+      "start": "2027-06-07",
+      "end": "2027-06-14",
+      "price": {
+        "amount": 2395.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-06-14-1",
+      "boat_slug": "all-star-red-sea",
+      "name": " Daedalus & St. John's (Port Ghalib - Port Ghalib)",
+      "start": "2027-06-14",
+      "end": "2027-06-21",
+      "price": {
+        "amount": 2395.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-06-21-2",
+      "boat_slug": "all-star-red-sea",
+      "name": " Daedalus & Fury Shoal (Port Ghalib - Port Ghalib)",
+      "start": "2027-06-21",
+      "end": "2027-06-28",
+      "price": {
+        "amount": 2395.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-06-28-3",
+      "boat_slug": "all-star-red-sea",
+      "name": " Daedalus & St. John's (Port Ghalib - Port Ghalib)",
+      "start": "2027-06-28",
+      "end": "2027-07-05",
+      "price": {
+        "amount": 2395.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=6/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-07-05-0",
+      "boat_slug": "all-star-red-sea",
+      "name": "20% Off: Ultimate Red Sea (Port Ghalib - Hurghada)",
+      "start": "2027-07-05",
+      "end": "2027-07-19",
+      "price": {
+        "amount": 3780.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-07-19-1",
+      "boat_slug": "all-star-red-sea",
+      "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-07-19",
+      "end": "2027-07-26",
+      "price": {
+        "amount": 2595.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-07-26-2",
+      "boat_slug": "all-star-red-sea",
+      "name": " North & Brothers (Hurghada - Hurghada)",
+      "start": "2027-07-26",
+      "end": "2027-08-02",
+      "price": {
+        "amount": 2595.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/LimitedAvailability",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=7/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-08-09-0",
+      "boat_slug": "all-star-red-sea",
+      "name": " North & Brothers (Hurghada - Hurghada)",
+      "start": "2027-08-09",
+      "end": "2027-08-16",
+      "price": {
+        "amount": 2595.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/SoldOut",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-08-16-1",
+      "boat_slug": "all-star-red-sea",
+      "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-08-16",
+      "end": "2027-08-23",
+      "price": {
+        "amount": 2025.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-08-23-2",
+      "boat_slug": "all-star-red-sea",
+      "name": " North & Tiran (Hurghada - Hurghada)",
+      "start": "2027-08-23",
+      "end": "2027-08-30",
+      "price": {
+        "amount": 2025.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
+      }
+    },
+    {
+      "id": "all-star-red-sea-2027-08-30-3",
+      "boat_slug": "all-star-red-sea",
+      "name": " North (Hurghada - Hurghada)",
+      "start": "2027-08-30",
+      "end": "2027-09-06",
+      "price": {
+        "amount": 2025.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=08/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/all-star-red-sea?m=8/2027"
       }
     },
     {
@@ -13851,4673 +2484,249 @@
       }
     },
     {
-      "id": "amelie-2027-05-01-0",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-04",
+      "id": "alsuraya-2027-06-05-0",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Brothers, Daedalus and Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-06-05",
+      "end": "2027-06-12",
       "price": {
-        "amount": 507.0,
+        "amount": 1416.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=06/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
       }
     },
     {
-      "id": "amelie-2027-05-05-1",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-05",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-09-2",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-09",
-      "end": "2027-05-12",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-13-3",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-13",
-      "end": "2027-05-16",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-17-4",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-17",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-21-5",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-21",
-      "end": "2027-05-24",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-25-6",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-25",
-      "end": "2027-05-28",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-2027-05-29-7",
-      "boat_slug": "amelie",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-01",
-      "price": {
-        "amount": 507.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-01-0",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-04",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-05-1",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-05",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-09-2",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-09",
-      "end": "2027-05-12",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-13-3",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-13",
-      "end": "2027-05-16",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-17-4",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-17",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-21-5",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-21",
-      "end": "2027-05-24",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-25-6",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-25",
-      "end": "2027-05-28",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "amelie-adventures-2027-05-29-7",
-      "boat_slug": "amelie-adventures",
-      "name": " Mini Safari: Best of Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-01",
-      "price": {
-        "amount": 565.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/amelie-adventures?m=5/2027"
-      }
-    },
-    {
-      "id": "aphrodite-2027-05-01-0",
-      "boat_slug": "aphrodite",
-      "name": " North Classic (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 2238.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      }
-    },
-    {
-      "id": "aphrodite-2027-05-08-1",
-      "boat_slug": "aphrodite",
-      "name": " North Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 2308.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      }
-    },
-    {
-      "id": "aphrodite-2027-05-15-2",
-      "boat_slug": "aphrodite",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 2389.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      }
-    },
-    {
-      "id": "aphrodite-2027-05-22-3",
-      "boat_slug": "aphrodite",
-      "name": " Deep South, St. John  (Port Ghalib\t- Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 2308.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      }
-    },
-    {
-      "id": "aphrodite-2027-05-29-4",
-      "boat_slug": "aphrodite",
-      "name": " Brothers - Daedalus - Elphinstone (Port Ghalib - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 2436.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/aphrodite?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-horizon-2027-05-01-0",
-      "boat_slug": "blue-horizon",
-      "name": " Brothers, Daedalus & Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1715.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-horizon-2027-05-08-1",
-      "boat_slug": "blue-horizon",
-      "name": "20% Off: Brothers, Daedalus & Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1372.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-horizon-2027-05-15-2",
-      "boat_slug": "blue-horizon",
-      "name": "20% Off: Northern Red Sea & Brothers (Hurghada - Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1204.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-horizon-2027-05-22-3",
-      "boat_slug": "blue-horizon",
-      "name": "20% Off: Daedalus & St. John's (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1372.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-horizon-2027-05-29-4",
-      "boat_slug": "blue-horizon",
-      "name": " Daedalus & St. John's (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1715.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-horizon?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-melody-2027-05-01-0",
-      "boat_slug": "blue-melody",
-      "name": " Brothers, Daedalus & Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1715.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-melody-2027-05-08-1",
-      "boat_slug": "blue-melody",
-      "name": "20% Off: Brothers, Daedalus & Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1372.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-melody-2027-05-15-2",
-      "boat_slug": "blue-melody",
-      "name": "20% Off: Brothers, Daedalus & Elphinstone (Hurghada - Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1372.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-melody-2027-05-22-3",
-      "boat_slug": "blue-melody",
-      "name": "20% Off: Daedalus & St. John's (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1372.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-melody-2027-05-29-4",
-      "boat_slug": "blue-melody",
-      "name": " Daedalus & St. John's (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1715.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-melody?m=5/2027"
-      }
-    },
-    {
-      "id": "blue-seas-2027-05-03-0",
-      "boat_slug": "blue-seas",
-      "name": " Rocky - Elba - St. John's - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-03",
-      "end": "2027-05-13",
-      "price": {
-        "amount": 2028.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/blue-seas?m=5/2027"
-      }
-    },
-    {
-      "id": "carlton-2027-05-01-0",
-      "boat_slug": "carlton",
-      "name": " Classic North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1084.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/carlton?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      }
-    },
-    {
-      "id": "carlton-2027-05-08-1",
-      "boat_slug": "carlton",
-      "name": " Classic North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1084.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/carlton?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      }
-    },
-    {
-      "id": "carlton-2027-05-15-2",
-      "boat_slug": "carlton",
-      "name": " Classic North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1084.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/carlton?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      }
-    },
-    {
-      "id": "carlton-2027-05-22-3",
-      "boat_slug": "carlton",
-      "name": " Classic North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1084.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/carlton?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      }
-    },
-    {
-      "id": "carlton-2027-05-29-4",
-      "boat_slug": "carlton",
-      "name": " Classic North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1084.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/carlton?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/carlton?m=5/2027"
-      }
-    },
-    {
-      "id": "destiny-2027-05-01-0",
-      "boat_slug": "destiny",
-      "name": " Daedalus - Fury Shoals - St. John's (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1631.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/destiny?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      }
-    },
-    {
-      "id": "destiny-2027-05-08-1",
-      "boat_slug": "destiny",
-      "name": " Brothers - Daedalus - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1631.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/destiny?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      }
-    },
-    {
-      "id": "destiny-2027-05-15-2",
-      "boat_slug": "destiny",
-      "name": " Fury Shoals - Elphinstone - Safaga (Port Ghalib - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1631.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/destiny?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      }
-    },
-    {
-      "id": "destiny-2027-05-22-3",
-      "boat_slug": "destiny",
-      "name": " North Tiran - Dahab (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1631.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/destiny?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      }
-    },
-    {
-      "id": "destiny-2027-05-29-4",
-      "boat_slug": "destiny",
-      "name": " Brothers - Daedalus - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1572.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/destiny?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/destiny?m=5/2027"
-      }
-    },
-    {
-      "id": "discovery-ii-2027-05-01-0",
-      "boat_slug": "discovery-ii",
-      "name": "15% Off: North Wrecks, Ras Mohamed, Tiran, Brothers, Safaga (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1090.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "discovery-ii-2027-05-08-1",
-      "boat_slug": "discovery-ii",
-      "name": "15% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1090.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "discovery-ii-2027-05-15-2",
-      "boat_slug": "discovery-ii",
-      "name": "15% Off: Brothers, Daedalus, Elphinstone (Hurghada - Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1090.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "discovery-ii-2027-05-22-3",
-      "boat_slug": "discovery-ii",
-      "name": "15% Off: Rocky, Zabargad, St. John's, Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1090.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "discovery-ii-2027-05-29-4",
-      "boat_slug": "discovery-ii",
-      "name": "15% Off: Daedalus, Rocky, Zabargad, Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1090.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/discovery-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-longara-2027-05-01-0",
-      "boat_slug": "dune-longara",
-      "name": " North Dahab Tiran (Safaga - Safaga)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-longara-2027-05-08-1",
-      "boat_slug": "dune-longara",
-      "name": " Golden Triangle (Safaga - Safaga )",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-longara-2027-05-15-2",
-      "boat_slug": "dune-longara",
-      "name": " Golden Triangle (Safaga - Ras Galep | Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-longara-2027-05-22-3",
-      "boat_slug": "dune-longara",
-      "name": " Golden Triangle (Ras Galep | Port Ghalib - Ras Galep | Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-longara-2027-05-29-4",
-      "boat_slug": "dune-longara",
-      "name": " Mixed South - Daedalus, Rocky & Zabargad Islands and St John’s (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1573.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-longara?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-silky-2027-05-01-0",
-      "boat_slug": "dune-silky",
-      "name": " St John's Reef (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-silky-2027-05-08-1",
-      "boat_slug": "dune-silky",
-      "name": " North Brothers (Marsa Ghalib - Safaga)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-silky-2027-05-15-2",
-      "boat_slug": "dune-silky",
-      "name": " North - Tiran (Safaga - Safaga)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-silky-2027-05-22-3",
-      "boat_slug": "dune-silky",
-      "name": " North - Tiran (Safaga - Safaga)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-silky-2027-05-29-4",
-      "boat_slug": "dune-silky",
-      "name": " Golden Triangle (Safaga - Safaga )",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-silky?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-titan-2027-05-01-0",
-      "boat_slug": "dune-titan",
-      "name": " St John's Reef (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-titan-2027-05-08-1",
-      "boat_slug": "dune-titan",
-      "name": " North Brothers (Safaga - Safaga)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-titan-2027-05-15-2",
-      "boat_slug": "dune-titan",
-      "name": " North Ras Mohammed (Safaga - Safaga)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-titan-2027-05-22-3",
-      "boat_slug": "dune-titan",
-      "name": " North - Tiran (Safaga - Safaga)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1340.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      }
-    },
-    {
-      "id": "dune-titan-2027-05-29-4",
-      "boat_slug": "dune-titan",
-      "name": " North Brothers (Safaga - Safaga)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/dune-titan?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-asmaa-2027-05-01-0",
-      "boat_slug": "emperor-asmaa",
-      "name": " Simply The Best (Hurghada - Marsa Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1515.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-asmaa-2027-05-08-1",
-      "boat_slug": "emperor-asmaa",
-      "name": " Daedalus, Fury and Elphinstone (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1457.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-asmaa-2027-05-15-2",
-      "boat_slug": "emperor-asmaa",
-      "name": " Simply the Best (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1573.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-asmaa-2027-05-22-3",
-      "boat_slug": "emperor-asmaa",
-      "name": " Southern Solitude (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1573.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-asmaa-2027-05-29-4",
-      "boat_slug": "emperor-asmaa",
-      "name": " South and St. Johns (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1515.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-asmaa?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-elite-2027-05-06-0",
-      "boat_slug": "emperor-elite",
-      "name": " South and St. Johns (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-06",
-      "end": "2027-05-13",
-      "price": {
-        "amount": 1807.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-elite-2027-05-13-1",
-      "boat_slug": "emperor-elite",
-      "name": " Southern Solitude (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-13",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-elite-2027-05-20-2",
-      "boat_slug": "emperor-elite",
-      "name": " Daedalus, Fury and Elphinstone (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-20",
-      "end": "2027-05-27",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-elite-2027-05-27-3",
-      "boat_slug": "emperor-elite",
-      "name": " Southern Solitude (Marsa Ghalib - Marsa Ghalib)",
-      "start": "2027-05-27",
-      "end": "2027-06-03",
-      "price": {
-        "amount": 1865.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-elite?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-superior-2027-05-01-0",
-      "boat_slug": "emperor-superior",
-      "name": " Reefs and Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1527.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-superior-2027-05-15-1",
-      "boat_slug": "emperor-superior",
-      "name": " Reefs and Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1527.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-superior-2027-05-22-2",
-      "boat_slug": "emperor-superior",
-      "name": " North & Easy (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1527.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-      }
-    },
-    {
-      "id": "emperor-superior-2027-05-29-3",
-      "boat_slug": "emperor-superior",
-      "name": " Reefs and Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1527.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/emperor-superior?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-adventure-2027-05-03-0",
-      "boat_slug": "ghazala-adventure",
-      "name": " Daedalus Rocky & St. Johns (Hurghada - Port Ghalib)",
-      "start": "2027-05-03",
-      "end": "2027-05-10",
-      "price": {
-        "amount": 1830.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-adventure-2027-05-10-1",
-      "boat_slug": "ghazala-adventure",
-      "name": " Brothers, Daedalus, Elphinstone (Port Ghalib - Hurghada)",
-      "start": "2027-05-10",
-      "end": "2027-05-17",
-      "price": {
-        "amount": 1830.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-adventure-2027-05-17-2",
-      "boat_slug": "ghazala-adventure",
-      "name": " North & Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-17",
-      "end": "2027-05-24",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-adventure-2027-05-24-3",
-      "boat_slug": "ghazala-adventure",
-      "name": " North: Wrecks & Reefs (Hurghada - Hurghada)",
-      "start": "2027-05-24",
-      "end": "2027-05-31",
-      "price": {
-        "amount": 1707.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-adventure-2027-05-31-4",
-      "boat_slug": "ghazala-adventure",
-      "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-31",
-      "end": "2027-06-07",
-      "price": {
-        "amount": 1830.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-adventure?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-explorer-2027-05-03-0",
-      "boat_slug": "ghazala-explorer",
-      "name": " North & Safaga (Hurghada - Hurghada)",
-      "start": "2027-05-03",
-      "end": "2027-05-10",
-      "price": {
-        "amount": 1725.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-explorer-2027-05-10-1",
-      "boat_slug": "ghazala-explorer",
-      "name": " North, Tiran & Dahab (Hurghada - Hurghada)",
-      "start": "2027-05-10",
-      "end": "2027-05-17",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-explorer-2027-05-24-2",
-      "boat_slug": "ghazala-explorer",
-      "name": " North: Wrecks & Reefs (Hurghada - Hurghada)",
-      "start": "2027-05-24",
-      "end": "2027-05-31",
-      "price": {
-        "amount": 1707.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "ghazala-explorer-2027-05-31-3",
-      "boat_slug": "ghazala-explorer",
-      "name": " Daedalus, Rocky & St Johns (Hurghada - Hurghada)",
-      "start": "2027-05-31",
-      "end": "2027-06-07",
-      "price": {
-        "amount": 1830.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ghazala-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "golden-dolphin-2027-05-06-0",
-      "boat_slug": "golden-dolphin",
-      "name": " North (Hurghada - Hurghada)",
-      "start": "2027-05-06",
-      "end": "2027-05-13",
+      "id": "alsuraya-2027-06-12-1",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: North and Brothers (Hurghada - Hurghada)",
+      "start": "2027-06-12",
+      "end": "2027-06-19",
       "price": {
         "amount": 1311.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=06/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
       }
     },
     {
-      "id": "golden-dolphin-2027-05-13-1",
-      "boat_slug": "golden-dolphin",
-      "name": " North - Brother Islands (Hurghada - Port Ghalib)",
-      "start": "2027-05-13",
-      "end": "2027-05-20",
+      "id": "alsuraya-2027-06-19-2",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Brothers, Daedalus and Elphinstone (Hurghada - Port Ghalib)",
+      "start": "2027-06-19",
+      "end": "2027-06-26",
       "price": {
-        "amount": 1385.0,
+        "amount": 1416.0,
         "currency": "USD"
       },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=05/2027",
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=06/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
       }
     },
     {
-      "id": "golden-dolphin-2027-05-20-2",
-      "boat_slug": "golden-dolphin",
-      "name": " North (Hurghada - Hurghada)",
-      "start": "2027-05-20",
-      "end": "2027-05-27",
+      "id": "alsuraya-2027-06-26-3",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Deadalus, St. John´s & Elphinstone (Port Ghalib - Port Ghalib)",
+      "start": "2027-06-26",
+      "end": "2027-07-03",
+      "price": {
+        "amount": 1416.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=06/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=6/2027"
+      }
+    },
+    {
+      "id": "alsuraya-2027-07-03-0",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Brothers, Daedalus and Elphinstone (Port Ghalib - Hurghada)",
+      "start": "2027-07-03",
+      "end": "2027-07-10",
+      "price": {
+        "amount": 1416.0,
+        "currency": "USD"
+      },
+      "availability": "https://schema.org/OnlineOnly",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=07/2027",
+      "location": "Egypt",
+      "provenance": {
+        "kind": "scraped",
+        "source_id": "liveaboard.com",
+        "retrieved": "2026-08-27",
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
+      }
+    },
+    {
+      "id": "alsuraya-2027-07-10-1",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: North and Brothers (Hurghada - Hurghada)",
+      "start": "2027-07-10",
+      "end": "2027-07-17",
       "price": {
         "amount": 1311.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=07/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
       }
     },
     {
-      "id": "golden-dolphin-2027-05-27-3",
-      "boat_slug": "golden-dolphin",
-      "name": " North - Brother Islands (Hurghada - Port Ghalib)",
-      "start": "2027-05-27",
-      "end": "2027-06-03",
+      "id": "alsuraya-2027-07-17-2",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Brothers, Daedalus and Elphinstone (Hurghada - Port Ghalib)",
+      "start": "2027-07-17",
+      "end": "2027-07-24",
       "price": {
-        "amount": 1385.0,
+        "amount": 1416.0,
         "currency": "USD"
       },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/golden-dolphin?m=5/2027"
-      }
-    },
-    {
-      "id": "grand-discovery-2027-05-01-0",
-      "boat_slug": "grand-discovery",
-      "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1288.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      }
-    },
-    {
-      "id": "grand-discovery-2027-05-08-1",
-      "boat_slug": "grand-discovery",
-      "name": "15% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1288.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      }
-    },
-    {
-      "id": "grand-discovery-2027-05-15-2",
-      "boat_slug": "grand-discovery",
-      "name": "15% Off: North Wrecks, Ras Mohamed, Tiran, Brothers & Safaga (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1263.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      }
-    },
-    {
-      "id": "grand-discovery-2027-05-22-3",
-      "boat_slug": "grand-discovery",
-      "name": "15% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1288.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      }
-    },
-    {
-      "id": "grand-discovery-2027-05-29-4",
-      "boat_slug": "grand-discovery",
-      "name": "15% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1288.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/grand-discovery?m=5/2027"
-      }
-    },
-    {
-      "id": "hammerhead-ii-2027-05-01-0",
-      "boat_slug": "hammerhead-ii",
-      "name": "15% Off: South Parks: Zabargad & Rocky - Saint John's (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1382.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "hammerhead-ii-2027-05-08-1",
-      "boat_slug": "hammerhead-ii",
-      "name": "15% Off: Deepest South: Abu Fandira - Sataya​​ (Fury Shoals) - St. John's (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1382.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "hammerhead-ii-2027-05-15-2",
-      "boat_slug": "hammerhead-ii",
-      "name": "15% Off: Brothers Light 3 (Marsa Alam - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-18",
-      "price": {
-        "amount": 658.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "hammerhead-ii-2027-05-22-3",
-      "boat_slug": "hammerhead-ii",
-      "name": " Red Sea Charm​: Abu Nuhas - SS Thistlegorm - The Brothers Islands - Safaga (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1315.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "hammerhead-ii-2027-05-29-4",
-      "boat_slug": "hammerhead-ii",
-      "name": "15% Off: Sharks Obsession: Brothers - Daedalus - Elphinstone (Hurghada - Marsa Alam)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1228.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/hammerhead-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "iceberg-2027-05-02-0",
-      "boat_slug": "iceberg",
-      "name": "10% Off: Special Wreck Trip - Thistlegorm-Abu Nuhas-Small Gobal (Hurghada - Hurghada)",
-      "start": "2027-05-02",
-      "end": "2027-05-06",
-      "price": {
-        "amount": 619.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      }
-    },
-    {
-      "id": "iceberg-2027-05-09-1",
-      "boat_slug": "iceberg",
-      "name": "10% Off: Hurghada North (Hurghada - Hurghada)",
-      "start": "2027-05-09",
-      "end": "2027-05-13",
-      "price": {
-        "amount": 619.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      }
-    },
-    {
-      "id": "iceberg-2027-05-16-2",
-      "boat_slug": "iceberg",
-      "name": "10% Off: Special Wreck Trip - Thistlegorm-Abu Nuhas-Small Gobal (Hurghada - Hurghada)",
-      "start": "2027-05-16",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 619.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      }
-    },
-    {
-      "id": "iceberg-2027-05-23-3",
-      "boat_slug": "iceberg",
-      "name": "10% Off: Hurghada North (Hurghada - Hurghada)",
-      "start": "2027-05-23",
-      "end": "2027-05-27",
-      "price": {
-        "amount": 619.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      }
-    },
-    {
-      "id": "iceberg-2027-05-30-4",
-      "boat_slug": "iceberg",
-      "name": "10% Off: Special Wreck Trip - Thistlegorm-Abu Nuhas-Small Gobal (Hurghada - Hurghada)",
-      "start": "2027-05-30",
-      "end": "2027-06-03",
-      "price": {
-        "amount": 619.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/iceberg?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/iceberg?m=5/2027"
-      }
-    },
-    {
-      "id": "jp-marine-2027-05-01-0",
-      "boat_slug": "jp-marine",
-      "name": "10% Off: Pelagic Trail: Big Fish - Hammerheads and Dolphins (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 984.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      }
-    },
-    {
-      "id": "jp-marine-2027-05-08-1",
-      "boat_slug": "jp-marine",
-      "name": "10% Off: Golden Mix: Daedalus, Sataya, St Johns, Rocky, Zabargad (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 984.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      }
-    },
-    {
-      "id": "jp-marine-2027-05-15-2",
-      "boat_slug": "jp-marine",
-      "name": "10% Off: Pelagic Trail: Big Fish - Hammerheads and Dolphins (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 984.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      }
-    },
-    {
-      "id": "jp-marine-2027-05-22-3",
-      "boat_slug": "jp-marine",
-      "name": "10% Off: Pelagic Trail: Big Fish - Hammerheads and Dolphins (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 984.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      }
-    },
-    {
-      "id": "jp-marine-2027-05-29-4",
-      "boat_slug": "jp-marine",
-      "name": "10% Off: Golden Mix: Daedalus, Sataya, St Johns, Rocky, Zabargad (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 984.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/jp-marine?m=5/2027"
-      }
-    },
-    {
-      "id": "marselia-star-2027-05-24-0",
-      "boat_slug": "marselia-star",
-      "name": " Safari Trip: Hurghada and Safaga (Hurghada - Hurghada)",
-      "start": "2027-05-24",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-      }
-    },
-    {
-      "id": "marselia-star-2027-05-29-1",
-      "boat_slug": "marselia-star",
-      "name": " Northern Wrecks and Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1515.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/marselia-star?m=5/2027"
-      }
-    },
-    {
-      "id": "oceanix-2027-05-08-0",
-      "boat_slug": "oceanix",
-      "name": "10% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1154.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/oceanix?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-      }
-    },
-    {
-      "id": "oceanix-2027-05-15-1",
-      "boat_slug": "oceanix",
-      "name": "10% Off: North & Wrecks Tour (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/oceanix?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-      }
-    },
-    {
-      "id": "oceanix-2027-05-22-2",
-      "boat_slug": "oceanix",
-      "name": " South & Safaga (Hurghada - Marsa Alam)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1154.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/oceanix?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/oceanix?m=5/2027"
-      }
-    },
-    {
-      "id": "odyssey-2027-05-01-0",
-      "boat_slug": "odyssey",
-      "name": " The Golden Loop: North - Brother - Safaga (Port Ghalib - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1655.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      }
-    },
-    {
-      "id": "odyssey-2027-05-08-1",
-      "boat_slug": "odyssey",
-      "name": " Best of Dahab and Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1772.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      }
-    },
-    {
-      "id": "odyssey-2027-05-15-2",
-      "boat_slug": "odyssey",
-      "name": " Best of Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1655.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      }
-    },
-    {
-      "id": "odyssey-2027-05-22-3",
-      "boat_slug": "odyssey",
-      "name": " Fury Shoal (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1655.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      }
-    },
-    {
-      "id": "odyssey-2027-05-29-4",
-      "boat_slug": "odyssey",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1876.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/odyssey?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/odyssey?m=5/2027"
-      }
-    },
-    {
-      "id": "queen-sherry-2027-05-01-0",
-      "boat_slug": "queen-sherry",
-      "name": " Pelagic Trail: Big fish – Hammerheads and Dolphins (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1230.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      }
-    },
-    {
-      "id": "queen-sherry-2027-05-08-1",
-      "boat_slug": "queen-sherry",
-      "name": " Golden Mix: Deadalus, Sataya, St. John's, Rocky, Zabargad (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1230.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      }
-    },
-    {
-      "id": "queen-sherry-2027-05-15-2",
-      "boat_slug": "queen-sherry",
-      "name": " Deep South Expedition: Secrets of Zabargad (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1230.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      }
-    },
-    {
-      "id": "queen-sherry-2027-05-22-3",
-      "boat_slug": "queen-sherry",
-      "name": " Pelagic Trail: Big fish – Hammerheads and Dolphins (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1230.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      }
-    },
-    {
-      "id": "queen-sherry-2027-05-29-4",
-      "boat_slug": "queen-sherry",
-      "name": " Golden Mix: Deadalus, Sataya, St. John's, Rocky, Zabargad (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1230.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/queen-sherry?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-ii-2027-05-01-0",
-      "boat_slug": "red-sea-aggressor-ii",
-      "name": "33% Off: Northern Red Sea, Ras Mohamed, Straits of Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1849.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-ii-2027-05-08-1",
-      "boat_slug": "red-sea-aggressor-ii",
-      "name": "33% Off: Northern Red Sea, Ras Mohamed, Straits of Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1849.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-ii-2027-05-15-2",
-      "boat_slug": "red-sea-aggressor-ii",
-      "name": "33% Off: Northern Red Sea - Best Wreck Diving (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1849.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-ii-2027-05-22-3",
-      "boat_slug": "red-sea-aggressor-ii",
-      "name": "33% Off: Northern Red Sea, Ras Mohamed, Straits of Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1849.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-ii-2027-05-29-4",
-      "boat_slug": "red-sea-aggressor-ii",
-      "name": "33% Off: Northern Red Sea, Ras Mohamed, Straits of Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1849.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-ii?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-iv-2027-05-01-0",
-      "boat_slug": "red-sea-aggressor-iv",
-      "name": "33% Off: St. Johns & Daedalus (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1808.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-iv-2027-05-08-1",
-      "boat_slug": "red-sea-aggressor-iv",
-      "name": "33% Off: St. Johns & Daedalus (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1808.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-iv-2027-05-15-2",
-      "boat_slug": "red-sea-aggressor-iv",
-      "name": "33% Off: St. Johns & Daedalus (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1808.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-iv-2027-05-22-3",
-      "boat_slug": "red-sea-aggressor-iv",
-      "name": "33% Off: Brothers, Daedalus, Elphinstone (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1808.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-iv-2027-05-29-4",
-      "boat_slug": "red-sea-aggressor-iv",
-      "name": "33% Off: St. Johns & Daedalus (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1808.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-iv?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-v-2027-05-01-0",
-      "boat_slug": "red-sea-aggressor-v",
-      "name": "33% Off: Deep South – Rocky & Zabargad Islands (Hamata - Hamata)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1875.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-v-2027-05-08-1",
-      "boat_slug": "red-sea-aggressor-v",
-      "name": "33% Off: Deep South – Elba Reef (Hamata - Hamata)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1875.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-v-2027-05-15-2",
-      "boat_slug": "red-sea-aggressor-v",
-      "name": "33% Off: Deep South – Rocky & Zabargad Islands (Hamata - Hamata)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1875.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-v-2027-05-22-3",
-      "boat_slug": "red-sea-aggressor-v",
-      "name": "33% Off: Deep South – Elba Reef (Hamata - Hamata)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1875.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-aggressor-v-2027-05-29-4",
-      "boat_slug": "red-sea-aggressor-v",
-      "name": "33% Off: Deep South – Rocky & Zabargad Islands (Hamata - Hamata)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1875.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-aggressor-v?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-blue-force-2-2027-05-01-0",
-      "boat_slug": "red-sea-blue-force-2",
-      "name": " Egypt - North Route (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1620.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-blue-force-2-2027-05-08-1",
-      "boat_slug": "red-sea-blue-force-2",
-      "name": " Extended North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-08",
-      "end": "2027-05-16",
-      "price": {
-        "amount": 1737.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-blue-force-2-2027-05-15-2",
-      "boat_slug": "red-sea-blue-force-2",
-      "name": " Extended North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-15",
-      "end": "2027-05-23",
-      "price": {
-        "amount": 1737.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-blue-force-2-2027-05-22-3",
-      "boat_slug": "red-sea-blue-force-2",
-      "name": " Extended North (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-22",
-      "end": "2027-05-30",
-      "price": {
-        "amount": 1737.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-blue-force-2-2027-05-29-4",
-      "boat_slug": "red-sea-blue-force-2",
-      "name": " Egypt - North Route (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1620.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-blue-force-2?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-explorer-2027-05-06-0",
-      "boat_slug": "red-sea-explorer",
-      "name": " Brother Islands, Daedalus & Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-06",
-      "end": "2027-05-13",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-explorer-2027-05-13-1",
-      "boat_slug": "red-sea-explorer",
-      "name": " St. Johns, Zabargad & Rocky (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-13",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-explorer-2027-05-20-2",
-      "boat_slug": "red-sea-explorer",
-      "name": " Daedalus & Fury Shoal (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-20",
-      "end": "2027-05-27",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "red-sea-explorer-2027-05-27-3",
-      "boat_slug": "red-sea-explorer",
-      "name": " St. John's (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-27",
-      "end": "2027-06-03",
-      "price": {
-        "amount": 1632.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/red-sea-explorer?m=5/2027"
-      }
-    },
-    {
-      "id": "royal-evolution-2027-05-03-0",
-      "boat_slug": "royal-evolution",
-      "name": "10% Off: Elba Reef | Elba borders (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-03",
-      "end": "2027-05-13",
-      "price": {
-        "amount": 2464.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-      }
-    },
-    {
-      "id": "royal-evolution-2027-05-13-1",
-      "boat_slug": "royal-evolution",
-      "name": "10% Off: Deadalus & Elba Reef (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-13",
-      "end": "2027-05-20",
-      "price": {
-        "amount": 1730.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-      }
-    },
-    {
-      "id": "royal-evolution-2027-05-20-2",
-      "boat_slug": "royal-evolution",
-      "name": "10% Off: Deadalus & Elba Reef (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-20",
-      "end": "2027-05-27",
-      "price": {
-        "amount": 1730.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-      }
-    },
-    {
-      "id": "royal-evolution-2027-05-27-3",
-      "boat_slug": "royal-evolution",
-      "name": "10% Off: Brothers, Daedalus, Rocky, St. John & Elba (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-27",
-      "end": "2027-06-06",
-      "price": {
-        "amount": 2464.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/royal-evolution?m=5/2027"
-      }
-    },
-    {
-      "id": "safy-mar-2027-05-01-0",
-      "boat_slug": "safy-mar",
-      "name": " Best of the South (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1772.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      }
-    },
-    {
-      "id": "safy-mar-2027-05-08-1",
-      "boat_slug": "safy-mar",
-      "name": " Central Red Sea Route (Port Ghalib - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      }
-    },
-    {
-      "id": "safy-mar-2027-05-15-2",
-      "boat_slug": "safy-mar",
-      "name": " Northern Wrecks and Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      }
-    },
-    {
-      "id": "safy-mar-2027-05-22-3",
-      "boat_slug": "safy-mar",
-      "name": " Central Red Sea Route (Hurghada - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1772.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      }
-    },
-    {
-      "id": "safy-mar-2027-05-29-4",
-      "boat_slug": "safy-mar",
-      "name": " Best of the North (Port Ghalib - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1690.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/safy-mar?m=5/2027"
-      }
-    },
-    {
-      "id": "sea-friend-2027-05-08-0",
-      "boat_slug": "sea-friend",
-      "name": " Sataya - Where Dolphins Touch Your Soul - Retreat (Hamata - Hamata)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 2040.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-friend?m=5/2027"
-      }
-    },
-    {
-      "id": "sea-serpent-2027-05-01-0",
-      "boat_slug": "sea-serpent",
-      "name": " North & Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1572.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-      }
-    },
-    {
-      "id": "sea-serpent-2027-05-22-1",
-      "boat_slug": "sea-serpent",
-      "name": " Daedalus & Fury Shoals (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1514.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent?m=5/2027"
-      }
-    },
-    {
-      "id": "sea-serpent-excellence-2027-05-22-0",
-      "boat_slug": "sea-serpent-excellence",
-      "name": " Daedalus & Fury Shoals (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1648.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-excellence?m=5/2027"
-      }
-    },
-    {
-      "id": "sea-serpent-grand-2027-05-20-0",
-      "boat_slug": "sea-serpent-grand",
-      "name": " North & Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-20",
-      "end": "2027-05-27",
-      "price": {
-        "amount": 1782.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sea-serpent-grand?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-01-0",
-      "boat_slug": "serenity",
-      "name": "20% Off: North & Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1305.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-08-1",
-      "boat_slug": "serenity",
-      "name": "20% Off: North and Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1259.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-15-2",
-      "boat_slug": "serenity",
-      "name": "20% Off: Mini Hurghada (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-18",
-      "price": {
-        "amount": 839.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-18-3",
-      "boat_slug": "serenity",
-      "name": "20% Off: Mini - Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-18",
-      "end": "2027-05-21",
-      "price": {
-        "amount": 839.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-22-4",
-      "boat_slug": "serenity",
-      "name": "20% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1352.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "serenity-2027-05-29-5",
-      "boat_slug": "serenity",
-      "name": "20% Off: North and Wrecks (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1259.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/serenity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/serenity?m=5/2027"
-      }
-    },
-    {
-      "id": "sinaistar-2027-05-01-0",
-      "boat_slug": "sinaistar",
-      "name": "30% Off: North Wrecks, Ras Mohamed, Tiran & Brothers Islands (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1020.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      }
-    },
-    {
-      "id": "sinaistar-2027-05-08-1",
-      "boat_slug": "sinaistar",
-      "name": "30% Off: North Reefs, Wrecks and Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 979.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      }
-    },
-    {
-      "id": "sinaistar-2027-05-15-2",
-      "boat_slug": "sinaistar",
-      "name": "30% Off: North Wrecks, Ras Mohamed, Tiran & Brothers Islands (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1020.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      }
-    },
-    {
-      "id": "sinaistar-2027-05-22-3",
-      "boat_slug": "sinaistar",
-      "name": "30% Off: North Reefs, Wrecks and Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 979.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      }
-    },
-    {
-      "id": "sinaistar-2027-05-29-4",
-      "boat_slug": "sinaistar",
-      "name": "30% Off: North Wrecks, Ras Mohamed, Tiran & Brothers Islands (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1020.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sinaistar?m=5/2027"
-      }
-    },
-    {
-      "id": "sindalahs-2027-05-01-0",
-      "boat_slug": "sindalahs",
-      "name": "20% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1596.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-      }
-    },
-    {
-      "id": "sindalahs-2027-05-08-1",
-      "boat_slug": "sindalahs",
-      "name": "20% Off: North Reef, Ras Mohamed, Tiran, Brothers Island (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1508.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-      }
-    },
-    {
-      "id": "sindalahs-2027-05-15-2",
-      "boat_slug": "sindalahs",
-      "name": "20% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1596.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-      }
-    },
-    {
-      "id": "sindalahs-2027-05-22-3",
-      "boat_slug": "sindalahs",
-      "name": "20% Off: North Reef, Ras Mohamed, Tiran, Brothers Island (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1508.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-      }
-    },
-    {
-      "id": "sindalahs-2027-05-29-4",
-      "boat_slug": "sindalahs",
-      "name": "20% Off: Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1596.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sindalahs?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-love-2027-05-06-0",
-      "boat_slug": "snefro-love",
-      "name": " Mini Plus: Thistlegorm - Tiran - Ras Mohamed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-06",
-      "end": "2027-05-10",
-      "price": {
-        "amount": 854.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-love-2027-05-13-1",
-      "boat_slug": "snefro-love",
-      "name": " Mini Plus: Thistlegorm - Tiran - Ras Mohamed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-13",
-      "end": "2027-05-17",
-      "price": {
-        "amount": 854.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-love-2027-05-20-2",
-      "boat_slug": "snefro-love",
-      "name": " Mini Plus: Thistlegorm - Tiran - Ras Mohamed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-20",
-      "end": "2027-05-24",
-      "price": {
-        "amount": 854.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-love-2027-05-27-3",
-      "boat_slug": "snefro-love",
-      "name": " Mini Plus: Thistlegorm - Tiran - Ras Mohamed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-27",
-      "end": "2027-05-31",
-      "price": {
-        "amount": 854.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-love?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-02-0",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-02",
-      "end": "2027-05-05",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-05-1",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-05",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-09-2",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-09",
-      "end": "2027-05-12",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-12-3",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-12",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-16-4",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-16",
-      "end": "2027-05-19",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-19-5",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-19",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-23-6",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-23",
-      "end": "2027-05-26",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-26-7",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-26",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-pearl-2027-05-30-8",
-      "boat_slug": "snefro-pearl",
-      "name": " Mini Safari: Thistlegorm - Ras Mohammed (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-30",
-      "end": "2027-06-02",
-      "price": {
-        "amount": 678.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-pearl?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-target-2027-05-01-0",
-      "boat_slug": "snefro-target",
-      "name": " Sinai Classic (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1471.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-target-2027-05-08-1",
-      "boat_slug": "snefro-target",
-      "name": " Sinai Classic (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1471.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-target-2027-05-15-2",
-      "boat_slug": "snefro-target",
-      "name": " Sinai Classic (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1471.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-target-2027-05-22-3",
-      "boat_slug": "snefro-target",
-      "name": " Sinai Classic (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1471.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      }
-    },
-    {
-      "id": "snefro-target-2027-05-29-4",
-      "boat_slug": "snefro-target",
-      "name": " Sinai Classic (Sharm El Sheikh - Sharm El Sheikh)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1471.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/snefro-target?m=5/2027"
-      }
-    },
-    {
-      "id": "ss-glorious-miss-nouran-2027-05-01-0",
-      "boat_slug": "ss-glorious-miss-nouran",
-      "name": " Fury Shoals (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1607.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-      }
-    },
-    {
-      "id": "ss-glorious-miss-nouran-2027-05-22-1",
-      "boat_slug": "ss-glorious-miss-nouran",
-      "name": " St. John's (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1724.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-      }
-    },
-    {
-      "id": "ss-glorious-miss-nouran-2027-05-29-2",
-      "boat_slug": "ss-glorious-miss-nouran",
-      "name": " Fury Shoals (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1607.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/ss-glorious-miss-nouran?m=5/2027"
-      }
-    },
-    {
-      "id": "star-jet-2027-05-01-0",
-      "boat_slug": "star-jet",
-      "name": " Rocky & Zabargad - St. John's - Elphinstone (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-      }
-    },
-    {
-      "id": "star-jet-2027-05-08-1",
-      "boat_slug": "star-jet",
-      "name": " Sataya (Fury Shoals) - St. John's (Marsa Alam - Marsa Alam)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-      }
-    },
-    {
-      "id": "star-jet-2027-05-15-2",
-      "boat_slug": "star-jet",
-      "name": " Safaga - Daedalus - Brothers (Marsa Alam - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-      }
-    },
-    {
-      "id": "star-jet-2027-05-22-3",
-      "boat_slug": "star-jet",
-      "name": " Tiran - Ras Muhammad - SS Thistlegorm (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-      }
-    },
-    {
-      "id": "star-jet-2027-05-29-4",
-      "boat_slug": "star-jet",
-      "name": " Safaga - Brothers - Abu Nuhas (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1282.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/star-jet?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/star-jet?m=5/2027"
-      }
-    },
-    {
-      "id": "sunlight-2027-05-01-0",
-      "boat_slug": "sunlight",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      }
-    },
-    {
-      "id": "sunlight-2027-05-08-1",
-      "boat_slug": "sunlight",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      }
-    },
-    {
-      "id": "sunlight-2027-05-15-2",
-      "boat_slug": "sunlight",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      }
-    },
-    {
-      "id": "sunlight-2027-05-22-3",
-      "boat_slug": "sunlight",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      }
-    },
-    {
-      "id": "sunlight-2027-05-29-4",
-      "boat_slug": "sunlight",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1049.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunlight?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunlight?m=5/2027"
-      }
-    },
-    {
-      "id": "sunshine-2027-05-01-0",
-      "boat_slug": "sunshine",
-      "name": " North - Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 874.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-      }
-    },
-    {
-      "id": "sunshine-2027-05-08-1",
-      "boat_slug": "sunshine",
-      "name": " North - Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 874.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-      }
-    },
-    {
-      "id": "sunshine-2027-05-15-2",
-      "boat_slug": "sunshine",
-      "name": " North - Dahab (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 991.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
-      }
-    },
-    {
-      "id": "sunshine-2027-05-22-3",
-      "boat_slug": "sunshine",
-      "name": " North - Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 874.0,
-        "currency": "USD"
-      },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=07/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
       }
     },
     {
-      "id": "sunshine-2027-05-29-4",
-      "boat_slug": "sunshine",
-      "name": " North - Tiran (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
+      "id": "alsuraya-2027-07-24-3",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Daedalus, Rocky, Zabargad & Elphinstone (Port Ghalib - Port Ghalib)",
+      "start": "2027-07-24",
+      "end": "2027-07-31",
       "price": {
-        "amount": 874.0,
+        "amount": 1469.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/sunshine?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=07/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/sunshine?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=7/2027"
       }
     },
     {
-      "id": "tala-2027-05-07-0",
-      "boat_slug": "tala",
-      "name": " North (Hurghada - Hurghada)",
-      "start": "2027-05-07",
-      "end": "2027-05-14",
+      "id": "alsuraya-2027-08-07-0",
+      "boat_slug": "alsuraya",
+      "name": " Deadalus, St. John´s & Elphinstone (Port Ghalib - Port Ghalib)",
+      "start": "2027-08-07",
+      "end": "2027-08-14",
       "price": {
         "amount": 1573.0,
         "currency": "USD"
       },
-      "availability": "https://schema.org/LimitedAvailability",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/tala?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-      }
-    },
-    {
-      "id": "tala-2027-05-16-1",
-      "boat_slug": "tala",
-      "name": " North & Dahab (Hurghada - Hurghada)",
-      "start": "2027-05-16",
-      "end": "2027-05-23",
-      "price": {
-        "amount": 1340.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/tala?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-      }
-    },
-    {
-      "id": "tala-2027-05-23-2",
-      "boat_slug": "tala",
-      "name": " North (Hurghada - Hurghada)",
-      "start": "2027-05-23",
-      "end": "2027-05-30",
-      "price": {
-        "amount": 1224.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/tala?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-      }
-    },
-    {
-      "id": "tala-2027-05-30-3",
-      "boat_slug": "tala",
-      "name": " Brothers, Daedalus, Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-30",
-      "end": "2027-06-06",
-      "price": {
-        "amount": 1457.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/tala?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/tala?m=5/2027"
-      }
-    },
-    {
-      "id": "unity-2027-05-01-0",
-      "boat_slug": "unity",
-      "name": " Brothers - Daedalus - Elphinstone (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1189.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/unity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-      }
-    },
-    {
-      "id": "unity-2027-05-08-1",
-      "boat_slug": "unity",
-      "name": " North and Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1189.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/unity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-      }
-    },
-    {
-      "id": "unity-2027-05-15-2",
-      "boat_slug": "unity",
-      "name": " The Grand Tour (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1364.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/unity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-      }
-    },
-    {
-      "id": "unity-2027-05-29-3",
-      "boat_slug": "unity",
-      "name": " North and Brothers (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1259.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/unity?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/unity?m=5/2027"
-      }
-    },
-    {
-      "id": "vita-xplorer-2027-05-01-0",
-      "boat_slug": "vita-xplorer",
-      "name": " Daedalus - Zabargad - Rocky Island - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-      }
-    },
-    {
-      "id": "vita-xplorer-2027-05-08-1",
-      "boat_slug": "vita-xplorer",
-      "name": " Daedalus - Zabargad - Rocky Island - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1399.0,
-        "currency": "USD"
-      },
       "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=08/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
       }
     },
     {
-      "id": "vita-xplorer-2027-05-15-2",
-      "boat_slug": "vita-xplorer",
-      "name": " Daedalus - Zabargad - Rocky Island - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
+      "id": "alsuraya-2027-08-14-1",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: North and Brothers (Hurghada - Hurghada)",
+      "start": "2027-08-14",
+      "end": "2027-08-21",
       "price": {
-        "amount": 1399.0,
+        "amount": 1311.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=08/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
       }
     },
     {
-      "id": "vita-xplorer-2027-05-22-3",
-      "boat_slug": "vita-xplorer",
-      "name": " Daedalus - Zabargad - Rocky Island - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
+      "id": "alsuraya-2027-08-21-2",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: Brothers, Daedalus and Elphinstone (Hurghada - Hurghada)",
+      "start": "2027-08-21",
+      "end": "2027-08-28",
       "price": {
-        "amount": 1399.0,
+        "amount": 1416.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=08/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
       }
     },
     {
-      "id": "vita-xplorer-2027-05-29-4",
-      "boat_slug": "vita-xplorer",
-      "name": " Daedalus - Zabargad - Rocky Island - Elphinstone (Port Ghalib - Port Ghalib)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
+      "id": "alsuraya-2027-08-28-3",
+      "boat_slug": "alsuraya",
+      "name": "10% Off: North and Brothers (Hurghada - Hurghada)",
+      "start": "2027-08-28",
+      "end": "2027-09-04",
       "price": {
-        "amount": 1399.0,
+        "amount": 1311.0,
         "currency": "USD"
       },
       "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=05/2027",
+      "booking_url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=08/2027",
       "location": "Egypt",
       "provenance": {
         "kind": "scraped",
         "source_id": "liveaboard.com",
         "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/vita-xplorer?m=5/2027"
-      }
-    },
-    {
-      "id": "yachtiano-2027-05-01-0",
-      "boat_slug": "yachtiano",
-      "name": " Yachtiano Deluxe (Hurghada - Hurghada)",
-      "start": "2027-05-01",
-      "end": "2027-05-08",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-      }
-    },
-    {
-      "id": "yachtiano-2027-05-08-1",
-      "boat_slug": "yachtiano",
-      "name": " Yachtiano Deluxe (Hurghada - Hurghada)",
-      "start": "2027-05-08",
-      "end": "2027-05-15",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-      }
-    },
-    {
-      "id": "yachtiano-2027-05-15-2",
-      "boat_slug": "yachtiano",
-      "name": " Yachtiano Deluxe (Hurghada - Hurghada)",
-      "start": "2027-05-15",
-      "end": "2027-05-22",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/SoldOut",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-      }
-    },
-    {
-      "id": "yachtiano-2027-05-22-3",
-      "boat_slug": "yachtiano",
-      "name": " Yachtiano Deluxe (Hurghada - Hurghada)",
-      "start": "2027-05-22",
-      "end": "2027-05-29",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
-      }
-    },
-    {
-      "id": "yachtiano-2027-05-29-4",
-      "boat_slug": "yachtiano",
-      "name": " Yachtiano Deluxe (Hurghada - Hurghada)",
-      "start": "2027-05-29",
-      "end": "2027-06-05",
-      "price": {
-        "amount": 1748.0,
-        "currency": "USD"
-      },
-      "availability": "https://schema.org/OnlineOnly",
-      "booking_url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=05/2027",
-      "location": "Egypt",
-      "provenance": {
-        "kind": "scraped",
-        "source_id": "liveaboard.com",
-        "retrieved": "2026-08-27",
-        "url": "https://www.liveaboard.com/diving/egypt/yachtiano?m=5/2027"
+        "url": "https://www.liveaboard.com/diving/egypt/alsuraya?m=8/2027"
       }
     }
   ],
   "warnings": [
-    "https://www.liveaboard.com/diving/egypt/ashrafi?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/avo?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/bella-2?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/bella-3?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/bismarck?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/blue?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/blue-diamond?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/blue-pearl?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/blue-storm?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/cu?m=5/2027: Product node but no Event nodes",
-    "unparsed https://www.liveaboard.com/diving/egypt/discovery-i?m=5/2027: no JSON-LD Event or Product node in https://www.liveaboard.com/diving/egypt/discovery-i?m=5/2027; inspect the snapshot (d7305cc688057495) and add a markup parser",
-    "https://www.liveaboard.com/diving/egypt/eriny?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/freedom-iii?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/freedom-iv?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/golden-dolphin-iv?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/golden-imperial?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/gordon-reef?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/gordon-reef?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/hamata?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/hamata?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/jackson-reef?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/jackson-reef?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/lady-m?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/new-sambo?m=5/2027: Product node but no Event nodes",
-    "unparsed https://www.liveaboard.com/diving/egypt/ocean-lovers?m=5/2027: no JSON-LD Event or Product node in https://www.liveaboard.com/diving/egypt/ocean-lovers?m=5/2027; inspect the snapshot (d37c2693a88a866a) and add a markup parser",
-    "https://www.liveaboard.com/diving/egypt/reef-voyager?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/rocky?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/rocky?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/salem-express?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/salem-express?m=5/2027: Product node but no Event nodes",
-    "unparsed https://www.liveaboard.com/diving/egypt/sea-serpent-contessa?m=5/2027: no JSON-LD Event or Product node in https://www.liveaboard.com/diving/egypt/sea-serpent-contessa?m=5/2027; inspect the snapshot (b16ddd65ce87e7ae) and add a markup parser",
-    "https://www.liveaboard.com/diving/egypt/shark-and-yolanda?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/shark-and-yolanda?m=5/2027: Product node but no Event nodes",
-    "unparsed https://www.liveaboard.com/diving/egypt/sinai?m=5/2027: no JSON-LD Event or Product node in https://www.liveaboard.com/diving/egypt/sinai?m=5/2027; inspect the snapshot (09b9d7851576c4ab) and add a markup parser",
-    "https://www.liveaboard.com/diving/egypt/south-moon-1?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/ss-serena-dreams?m=5/2027: Product node but no Event nodes",
-    "unparsed https://www.liveaboard.com/diving/egypt/topaz?m=5/2027: no JSON-LD Event or Product node in https://www.liveaboard.com/diving/egypt/topaz?m=5/2027; inspect the snapshot (d36d981494764194) and add a markup parser",
-    "https://www.liveaboard.com/diving/egypt/woodhouse-reef?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/woodhouse-reef?m=5/2027: Product node but no Event nodes",
-    "https://www.liveaboard.com/diving/egypt/zabargad?m=5/2027: no Required/Optional Extras block found",
-    "https://www.liveaboard.com/diving/egypt/zabargad?m=5/2027: Product node but no Event nodes",
+    "https://www.liveaboard.com/diving/egypt/alia-soul?m=7/2027: Product node but no Event nodes",
     "/diving/search/egypt/may/2027: 88 boats",
-    "/diving/search/egypt/june/2027: 88 boats",
-    "/diving/search/egypt/july/2027: 88 boats",
-    "/diving/search/egypt/august/2027: 88 boats",
-    "no boat links matched on https://www.liveaboard.com/diving/egypt",
-    "no boat links matched on https://www.liveaboard.com/diving/egypt/red-sea"
+    "stopped at 4 vessels; more were available"
   ]
 }


### PR DESCRIPTION
The small run scraped correctly and published none of it.

```
57 departures · May 19 · June 13 · July 11 · August 14 · 4 vessels
clean fee lines, no fabrications
```

Then `promote` was turned away by its shrink guard, because `--force` never arrived.

A `workflow_dispatch` boolean input is a **real boolean**, and GitHub casts across types to number when comparing — so `inputs.force_promote == 'true'` evaluates `1 == NaN`, which is false. The flag was silently dropped on every run. Now the input is tested directly.

The step is `continue-on-error`, so the guard's refusal didn't fail the run: the site rebuilt from the previous dataset and the commit carried only a new candidate file. Correct behaviour from the guard — invisible because nothing downstream noticed the dataset hadn't moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_