### PR TITLE
Give the four scraped vessels real ports, routes and sites

### DIFF
--- a/src/liveaboard/classify.py
+++ b/src/liveaboard/classify.py
@@ -32,7 +32,12 @@ def normalise(name: str) -> str:
     # Apostrophes are dropped rather than spaced, so "Sha'ab" and "Shaab" agree
     # and "St John's" matches "St Johns". Spacing them apart would split one
     # word into two and quietly break every signature that contains one.
-    folded = re.sub(r"['’ʿʼ`]", "", folded)
+    #
+    # The acute accent and the left single quote are in this class because
+    # operators type them for an apostrophe: a live title read "St. John´s"
+    # (U+00B4) and folded to "st john s", so the St John's route went
+    # unrecognised on two of four vessels.
+    folded = re.sub(r"['’‘ʿʼ`´]", "", folded)
     folded = re.sub(r"[^a-z0-9]+", " ", folded)
     return re.sub(r"\s+", " ", folded).strip()
 

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -19,6 +19,8 @@ from collections import defaultdict
 from datetime import date
 from typing import Any
 
+from .classify import normalise
+
 UNKNOWN_OPERATOR = {
     "id": "unknown-operator",
     "name": "Operator not captured",
@@ -35,6 +37,53 @@ MAX_NIGHTS = 30
 
 def slugify(value: str) -> str:
     return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", value.lower())).strip("-")
+
+
+PROMOTION = re.compile(r"^\s*(\d{1,2}\s*%\s*off)\s*:\s*", re.I)
+"""A discount banner the operator glues to the front of a trip title.
+
+Every scraped title carrying one has a twin without it — "20% Off: North &
+Tiran (Hurghada - Hurghada)" and "North & Tiran (Hurghada - Hurghada)" are the
+same week on the same boat, differing only in which departures were on offer.
+Grouping on the raw title split them into two cards, so a vessel appeared to
+sell routes it does not and the discounted departures sat under a separate
+heading from the rest.
+
+The discount is real price information, so it moves to the departures it
+applies to rather than being dropped. The route name stays a route name:
+carrying an operator's marketing into our own headline is the opposite of what
+this site is for.
+"""
+
+PORTS = re.compile(r"\(([^()]{2,60}?)\s+[-–]\s+([^()]{2,60}?)\)\s*$")
+"""The departure and return ports, which the title states and the data does not.
+
+liveaboard.com's Event location is the country — every itinerary promoted as
+"Egypt → Egypt", which tells a visitor nothing. The title ends with the real
+pair: "(Port Ghalib - Safaga/Soma Bay)". That distinction decides which
+airport someone flies into and whether they need two of them, so it is worth
+reading off the only place the source puts it.
+"""
+
+
+def _split_title(name: str) -> tuple[str, str | None, tuple[str, str] | None]:
+    """Split a scraped trip title into route, promotion and ports."""
+    promotion = None
+    match = PROMOTION.match(name)
+    if match:
+        promotion = " ".join(match.group(1).split())
+        name = name[match.end():].strip()
+
+    ports = None
+    match = PORTS.search(name)
+    if match:
+        first, second = (" ".join(p.split()) for p in match.groups())
+        # A parenthetical is only a port pair when it reads like one. "(Brothers
+        # - Daedalus)" is a route, and filing Daedalus as a harbour would put a
+        # reef on the page as somewhere to fly into.
+        if not _sites_from_name(f"{first} {second}"):
+            ports = (first, second)
+    return name.strip(), promotion, ports
 
 
 def _nights(start: str, end: str) -> int | None:
@@ -85,8 +134,10 @@ def promote(
             continue
         if season and not (season[0] <= date.fromisoformat(departure["start"]) <= season[1]):
             continue
-        name = (departure.get("name") or "Unnamed itinerary").strip()
-        grouped[(slug, name)].append({**departure, "nights": nights})
+        name, promotion, _ = _split_title(departure.get("name") or "Unnamed itinerary")
+        grouped[(slug, name or "Unnamed itinerary")].append(
+            {**departure, "nights": nights, "promotion": promotion}
+        )
 
     boats: dict[str, dict[str, Any]] = {}
     itineraries: list[dict[str, Any]] = []
@@ -102,7 +153,13 @@ def promote(
 
         itinerary_id = f"{slug}--{slugify(name)}"[:96]
         nights = _most_common(d["nights"] for d in group)
-        ports = [d.get("location") for d in group if d.get("location")]
+
+        # The title's port pair beats the Event location, which is the country.
+        _, _, titled_ports = _split_title(name)
+        located = [d.get("location") for d in group if d.get("location")]
+        port_from, port_to = titled_ports or (
+            (located[0], located[0]) if located else ("Unknown", "Unknown")
+        )
 
         itineraries.append(
             {
@@ -112,8 +169,8 @@ def promote(
                 "boat_id": slug,
                 "nights": nights,
                 "dives": 0,
-                "port_from": ports[0] if ports else "Unknown",
-                "port_to": ports[0] if ports else "Unknown",
+                "port_from": port_from,
+                "port_to": port_to,
                 # Left empty on purpose. Route and theme are derived from dive
                 # sites, which this source does not publish; the classifier
                 # falls back to the trip name, which usually carries them.
@@ -127,17 +184,21 @@ def promote(
         )
 
         for item in group:
-            departures.append(
-                {
-                    "id": item["id"],
-                    "itinerary_id": itinerary_id,
-                    "start": item["start"],
-                    "end": item["end"],
-                    "price": item["price"],
-                    "booking_url": item.get("booking_url"),
-                    "provenance": item["provenance"],
-                }
-            )
+            entry = {
+                "id": item["id"],
+                "itinerary_id": itinerary_id,
+                "start": item["start"],
+                "end": item["end"],
+                "price": item["price"],
+                "booking_url": item.get("booking_url"),
+                "provenance": item["provenance"],
+            }
+            # Carried on the departure, not the itinerary: the operator
+            # discounts specific dates, and the price shown is already the
+            # discounted one. This says why it is lower than its neighbours.
+            if item.get("promotion"):
+                entry["promotion"] = item["promotion"]
+            departures.append(entry)
 
     payload: dict[str, Any] = {
         "schema_version": 1,
@@ -182,11 +243,53 @@ it goes. Pulling the names back out of the title lets the existing classifier
 work unchanged instead of leaving every scraped trip unclassified.
 """
 
+SITE_ALIASES: dict[str, str] = {
+    "deadalus": "daedalus",
+    "rocky": "rocky island",
+    "st john": "st johns",
+    "saint johns": "st johns",
+}
+"""How operators actually spell a site in a trip title.
+
+Titles are marketing copy, not a gazetteer. Two of four vessels sell
+"Deadalus, St. John´s & Elphinstone" — one transposition and one acute accent
+— and a third abbreviates Rocky Island to "Rocky". Matching only the correct
+spelling dropped Daedalus and St John's from those routes, and since
+classification derives from dive sites, it filed a southern shark itinerary as
+a single-site trip.
+
+Keys are matched after :func:`~liveaboard.classify.normalise`, so accents and
+apostrophes are already folded; only genuine misspellings and short forms
+belong here.
+"""
+
 
 def _sites_from_name(name: str) -> list[str]:
-    """Recover dive-site names from an itinerary title."""
-    lowered = name.lower()
-    return [hint for hint in SITE_HINTS if hint in lowered]
+    """Recover dive-site names from an itinerary title.
+
+    Both sides are folded through the classifier's own :func:`normalise`, so
+    "St. John´s" in a title reaches the same key as "St Johns" in the hints
+    rather than missing it over punctuation.
+    """
+    folded = f" {normalise(name)} "
+    found: list[str] = []
+    # Keyed on the folded form: SITE_HINTS lists "st johns" and "st john's"
+    # separately for readability, and they are one site.
+    seen: set[str] = set()
+
+    def add(site: str) -> None:
+        key = normalise(site)
+        if key not in seen:
+            seen.add(key)
+            found.append(site)
+
+    for hint in SITE_HINTS:
+        if f" {normalise(hint)} " in folded:
+            add(hint)
+    for alias, canonical in SITE_ALIASES.items():
+        if f" {normalise(alias)} " in folded:
+            add(canonical)
+    return found
 
 
 def _default_fx() -> dict[str, Any]:

--- a/src/liveaboard/scrape/fees.py
+++ b/src/liveaboard/scrape/fees.py
@@ -292,6 +292,37 @@ def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
     return found
 
 
+EXCERPT_CHARS = 1500
+"""How much of each Required/Optional block is kept as evidence.
+
+The reference disclosure is under 300 characters. This is generous enough to
+hold a long one whole, and small enough that keeping one per vessel does not
+turn the fee book into a page dump.
+"""
+
+
+def extras_excerpt(text: str, limit: int = EXCERPT_CHARS) -> dict[str, str]:
+    """Return the disclosure text :func:`parse_extras` reads, for the record.
+
+    The fee book is the one input this project cannot rebuild without a
+    browser, and it stored only the parsed result. So when the parser was found
+    to be inventing charges, there was no way to check the fix against what the
+    page had actually said — the published fabrications had to be re-derived
+    from their own ``note`` fields, and confirming the fix meant driving a
+    browser at the live site again.
+
+    Keeping the text the parse was made from turns the next parser fix into a
+    replay instead of another live run, and makes "did the operator change
+    this, or did we?" answerable from the repository alone.
+    """
+    blocks: dict[str, str] = {}
+    for heading, body in BLOCK.findall(normalise_disclosure(text)):
+        excerpt = " ".join(body.split())[:limit]
+        if excerpt:
+            blocks[heading.lower()] = excerpt
+    return blocks
+
+
 def to_fee_dicts(fees: list[ParsedFee], provenance: dict) -> list[dict]:
     """Render parsed extras into the dataset's fee shape."""
     out = []

--- a/tests/test_fees.py
+++ b/tests/test_fees.py
@@ -12,6 +12,7 @@ from liveaboard.models import FeeItem
 from liveaboard.scrape.base import FetchResult, PoliteFetcher
 from liveaboard.scrape.fees import (
     classify_label,
+    extras_excerpt,
     normalise_disclosure,
     parse_extras,
     to_fee_dicts,
@@ -310,6 +311,39 @@ class TestPublishedFabrications(unittest.TestCase):
         """Six words is the line: no real extra needs a seventh."""
         self.assertIsNotNone(classify_label("Laundry / Pressing Services"))
         self.assertIsNone(classify_label("Nitrox is available on request for all guests"))
+
+
+class TestDisclosureExcerpt(unittest.TestCase):
+    """The fee book keeps what it parsed, so a fix can be replayed offline."""
+
+    def setUp(self):
+        self.blocks = extras_excerpt(REAL)
+
+    def test_both_blocks_are_kept(self):
+        self.assertEqual(set(self.blocks), {"required", "optional"})
+
+    def test_the_text_the_parser_read_is_recoverable(self):
+        self.assertIn("Environment Tax", self.blocks["required"])
+        self.assertIn("Laundry / Pressing Services", self.blocks["optional"])
+
+    def test_a_page_dump_is_bounded(self):
+        """One vessel's evidence must not become a copy of its whole page."""
+        flooded = REAL + " " + ("filler words that run on and on " * 400)
+        for excerpt in extras_excerpt(flooded).values():
+            self.assertLessEqual(len(excerpt), 1500)
+
+    def test_replaying_the_excerpt_reproduces_the_parse(self):
+        """The point of storing it: same text in, same fees out."""
+        replayed = parse_extras(
+            "Required Extras: " + self.blocks["required"]
+            + " Optional Extras: " + self.blocks["optional"]
+        )
+        self.assertEqual(
+            [f.code for f in replayed], [f.code for f in parse_extras(REAL)]
+        )
+
+    def test_a_page_with_no_disclosure_yields_nothing(self):
+        self.assertEqual(extras_excerpt("Boat Specifications Year built 2023"), {})
 
 
 if __name__ == "__main__":

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -246,5 +246,116 @@ class TestFeeMerge(unittest.TestCase):
         self.assertGreater(breakdown.total_max.amount, breakdown.total.amount)
 
 
+class TestPortsFromTitle(unittest.TestCase):
+    """The source's Event location is "Egypt"; the title names real harbours."""
+
+    def promote_one(self, name: str, location: str | None = "Egypt") -> dict:
+        payload = promote(
+            candidate([departure(name=name, location=location)]), season=SEASON
+        )
+        return payload["itineraries"][0]
+
+    def test_a_round_trip_reads_both_ports(self):
+        itinerary = self.promote_one("North & Tiran (Hurghada - Hurghada)")
+        self.assertEqual(itinerary["port_from"], "Hurghada")
+        self.assertEqual(itinerary["port_to"], "Hurghada")
+
+    def test_a_one_way_keeps_its_two_ports(self):
+        """A visitor books two airports off this; averaging them is a lie."""
+        itinerary = self.promote_one(
+            "Marine Park North: Brothers - Daedalus & Elphinstone "
+            "(Port Ghalib - Safaga/Soma Bay)"
+        )
+        self.assertEqual(itinerary["port_from"], "Port Ghalib")
+        self.assertEqual(itinerary["port_to"], "Safaga/Soma Bay")
+
+    def test_the_title_beats_the_country_the_source_reports(self):
+        itinerary = self.promote_one("North (Hurghada - Hurghada)")
+        self.assertNotEqual(itinerary["port_from"], "Egypt")
+
+    def test_a_route_in_brackets_is_not_mistaken_for_ports(self):
+        """"(Brothers - Daedalus)" is a route. Neither is a harbour."""
+        itinerary = self.promote_one("Red Sea Classic (Brothers - Daedalus)")
+        self.assertEqual(itinerary["port_from"], "Egypt")
+
+    def test_no_ports_anywhere_stays_unknown(self):
+        itinerary = self.promote_one("Ultimate Red Sea", location=None)
+        self.assertEqual(itinerary["port_from"], "Unknown")
+
+
+class TestPromotionalTitles(unittest.TestCase):
+    """A discount banner on the title split one trip across two cards."""
+
+    NAME = "North & Tiran (Hurghada - Hurghada)"
+
+    def setUp(self):
+        self.payload = promote(
+            candidate(
+                [
+                    departure(name=f"20% Off: {self.NAME}", start="2027-05-01",
+                              end="2027-05-08", price=1100.0),
+                    departure(name=self.NAME, start="2027-06-05",
+                              end="2027-06-12", price=1450.0),
+                ]
+            ),
+            season=SEASON,
+        )
+
+    def test_the_same_route_is_one_itinerary(self):
+        self.assertEqual(len(self.payload["itineraries"]), 1)
+
+    def test_the_route_name_carries_no_marketing(self):
+        self.assertEqual(self.payload["itineraries"][0]["name"], self.NAME)
+
+    def test_both_departures_survive_the_merge(self):
+        self.assertEqual(len(self.payload["departures"]), 2)
+
+    def test_the_discount_moves_to_the_departure_it_applies_to(self):
+        """It explains why one date is cheaper, so it is kept, not dropped."""
+        by_start = {d["start"]: d for d in self.payload["departures"]}
+        self.assertEqual(by_start["2027-05-01"]["promotion"], "20% Off")
+        self.assertNotIn("promotion", by_start["2027-06-05"])
+
+    def test_a_percentage_inside_the_route_name_is_left_alone(self):
+        payload = promote(
+            candidate([departure(name="Nitrox 32% Special (Hurghada - Hurghada)")]),
+            season=SEASON,
+        )
+        self.assertEqual(
+            payload["itineraries"][0]["name"], "Nitrox 32% Special (Hurghada - Hurghada)"
+        )
+
+
+class TestSiteRecoveryFromTitles(unittest.TestCase):
+    """Operators spell sites the way they like; the classifier needs them anyway."""
+
+    def sites(self, name: str) -> list[str]:
+        from liveaboard.promote import _sites_from_name
+
+        return _sites_from_name(name)
+
+    def test_an_acute_accent_still_reads_as_st_johns(self):
+        """A live title read "St. John´s" and folded to "st john s"."""
+        self.assertIn("st johns", self.sites("Deadalus, St. John´s & Elphinstone"))
+
+    def test_a_transposed_daedalus_is_still_daedalus(self):
+        self.assertIn("daedalus", self.sites("Deadalus, St. John´s & Elphinstone"))
+
+    def test_rocky_is_rocky_island(self):
+        self.assertIn(
+            "rocky island", self.sites("Marine Park South: Daedalus - Rocky - Zabargad")
+        )
+
+    def test_one_site_is_listed_once_however_it_is_spelled(self):
+        """SITE_HINTS carries "st johns" and "st john's"; they are one site."""
+        found = self.sites("Daedalus & St. John's")
+        self.assertEqual(len(found), len(set(found)))
+        self.assertEqual(len(found), 2)
+
+    def test_a_site_name_inside_a_longer_word_is_not_a_match(self):
+        """Substring matching is what put invented data on the page once."""
+        self.assertEqual(self.sites("Saidian Coast Special"), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scrape_fees.py
+++ b/tools/scrape_fees.py
@@ -30,7 +30,11 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from liveaboard.scrape.fees import parse_extras, to_fee_dicts  # noqa: E402
+from liveaboard.scrape.fees import (  # noqa: E402
+    extras_excerpt,
+    parse_extras,
+    to_fee_dicts,
+)
 from liveaboard.scrape.liveaboard_com import (  # noqa: E402
     HOST,
     SEASON_QUERY,
@@ -151,6 +155,10 @@ def main() -> int:
                 unpriced = sum(1 for f in fees if not f.has_price)
                 collected[slug] = {
                     "source_url": url,
+                    # What the parse was made from. Without it a parser fix
+                    # cannot be checked without driving a browser at the live
+                    # site all over again.
+                    "disclosure": extras_excerpt(text),
                     "fees": to_fee_dicts(
                         fees,
                         {


### PR DESCRIPTION
Four defects found by reading the promoted data for the vessels now on the site, rather than the code that produced it.

## Ports

Every itinerary published as **"Egypt → Egypt"** — the source's Event location is the country. The title states the real pair, and five of twenty-two trips turn out to be one-way:

```
Marine Park North: Brothers - Daedalus & Elphinstone   Port Ghalib -> Safaga/Soma Bay   one way
Brothers, Daedalus and Elphinstone                        Hurghada -> Port Ghalib       one way
Ultimate Red Sea                                       Port Ghalib -> Hurghada          one way
```

That decides which airport someone flies into and whether they need two. `render.py` has carried a `one_way` flag and `app.js` a "(one way)" label since the beginning; neither had ever fired.

A parenthetical is only read as ports when it doesn't parse as a route, so "(Brothers - Daedalus)" cannot file a reef as a harbour.

## Duplicate cards

`20% Off: North & Tiran (Hurghada - Hurghada)` and `North & Tiran (Hurghada - Hurghada)` are the same week on the same boat. Grouping on the raw title split them in two, so a vessel appeared to sell routes it does not and its discounted dates sat under a separate heading from the rest. **26 itineraries were really 22**, with all 57 departures intact.

The discount is real price information, so it moves to the 19 departures it applies to — where it explains why one date is cheaper — rather than being dropped or carried into our own headline.

## Site names

Two vessels sell `Deadalus, St. John´s & Elphinstone` (one transposition, one U+00B4 acute accent for an apostrophe); a third abbreviates Rocky Island to "Rocky". Matching only the correct spelling dropped those sites, and since classification derives from dive sites, a southern shark itinerary was filed `unclassified` / `open_water`. It now reads `deep_south` / `advanced_50`.

Both sides fold through the classifier's own `normalise` — which gains `´` and `‘`, since "St. John´s" folded to `st john s` — and match on word boundaries rather than substrings.

## Fee evidence

`data/fees.json` is the one input this project cannot rebuild without a browser, and it stored only the parsed result. So when the parser was found inventing charges, there was no way to check the fix against what the page had actually said — the fabrications had to be re-derived from their own `note` fields. It now keeps the disclosure text it parsed (bounded to 1500 characters per block), which turns the next parser fix into a replay instead of another live run.

## Verification

Re-promoting the live candidate: 26 → 22 itineraries, 57 departures kept, 19 discounts labelled, every port pair real, zero `Egypt → Egypt`. 162 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_