### PR TITLE
Stop dropping fees the operators do list

### DIFF
--- a/src/liveaboard/scrape/fees.py
+++ b/src/liveaboard/scrape/fees.py
@@ -49,7 +49,7 @@ ENTRY = re.compile(
         \s*(?:/\s*(?P<basis>trip|item|day|night|dive|person))?
         [^)]*
     \))?
-    \s*(?:,|\.|$)
+    \s*(?P<end>[,.]|$)
     """,
     re.I | re.X,
 )
@@ -96,16 +96,32 @@ none reaches seven words, while every fabrication above exceeds it.
 # match whole words, and the vaguest ones ("fuel", "course", "transfer") carry
 # enough context to mean only the fee.
 LABEL_PATTERNS: tuple[tuple[str, FeeCode], ...] = (
+    # Required on three of twelve vessels and previously nameless, so it was
+    # dropped from the true cost of every one of them.
+    (r"\b(?:mandatory\s+)?service\s+charge\b", FeeCode.SERVICE_CHARGE),
     (r"\bnational park\b|\bmarine park\b|\bpark fees?\b", FeeCode.MARINE_PARK),
     (r"\benvironment(?:al)?\s+tax\b|\beco\s+tax\b", FeeCode.ENVIRONMENT_TAX),
     (r"\bfuel\s+(?:surcharge|fee|supplement)\b", FeeCode.FUEL_SURCHARGE),
     (r"\bport\s+fees?\b|\bharbou?r\s+(?:fees?|dues)\b", FeeCode.PORT_FEES),
-    (r"\bnitrox\s+course\b|\bdiving\s+courses?\b|\bscuba\s+courses?\b|\bcourses?\b",
-     FeeCode.COURSE),
+    # Split from the general course line for the same reason as snorkel gear:
+    # vessels list "Nitrox Course (€99)" and "Scuba Diving Courses (€79-110)"
+    # as separate priced entries, and one entry per code drops the second.
+    (r"\bnitrox\s+course\b|\benriched\s+air\s+course\b", FeeCode.NITROX_COURSE),
+    (r"\bdiving\s+courses?\b|\bscuba\s+courses?\b|\bcourses?\b", FeeCode.COURSE),
     (r"\bnitrox\b|\benriched\s+air\b", FeeCode.NITROX),
     (r"\b(?:private\s+)?dive\s+guide\b|\bprivate\s+guide\b", FeeCode.PRIVATE_GUIDE),
+    # Ahead of the general gear line so "Snorkel Gear" keeps its own code.
+    # They are separate lines on the operator's own list, and one entry per
+    # code means folding them together would drop whichever came second.
+    (r"\bsnorkell?(?:ing)?\s+(?:gear|equipment|set)\b", FeeCode.SNORKEL_GEAR),
     (r"\b(?:rental|hire)\s+(?:gear|equipment)\b|\b(?:gear|equipment)\s+(?:rental|hire)\b",
      FeeCode.GEAR_RENTAL),
+    (r"\bnaturalist\s+guide\b|\bsnorkell?(?:ing)?\s+guide\b", FeeCode.NATURALIST_GUIDE),
+    (r"\bextra\s+dives?\b|\badditional\s+dives?\b", FeeCode.EXTRA_DIVES),
+    (r"\b(?:land\s+)?excursions?\b", FeeCode.LAND_EXCURSION),
+    # Narrow on purpose: the boat-features list that follows the disclosure
+    # carries "Beer available" and "Wine Available" as amenities, not charges.
+    (r"\balcoholic\s+(?:beverages?|drinks?)\b|\balcohol\b", FeeCode.ALCOHOL),
     (r"\bgratuit\w*\b|\bcrew\s+tips?\b|\btipping\b", FeeCode.GRATUITIES),
     (r"\blaundry\b|\bpressing\s+services?\b", FeeCode.LAUNDRY),
     (r"\bvisas?\s*(?:fees?|on\s+arrival)?\b(?!\w)", FeeCode.VISA),
@@ -166,6 +182,37 @@ braces or angle brackets is page furniture, not a price.
 """
 
 
+COMBINED_PARTS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\bparks?\b",
+        r"\bports?\b|\bharbou?rs?\b",
+        r"\bfuel\b",
+        r"\benvironment(?:al)?\b|\beco\b",
+    )
+)
+COMBINED_TAIL = re.compile(r"\b(?:fees?|charges?|taxes?|dues)\b", re.I)
+
+
+def _combined_fee(label: str) -> bool:
+    """Is this one charge covering several of the mandatory fees at once?
+
+    Operators bill "Park, Port and Fuel Fees (€200-450 / trip)" and "Park and
+    Port Fees (€130 / trip)" as a single line. Matching those against the
+    individual patterns either failed outright — the words are not adjacent, so
+    one vessel lost its whole required block, €280 to €530 of mandatory cost —
+    or filed the lot under whichever component happened to sit last, calling a
+    combined charge "port dues".
+
+    It stays one line carrying the whole amount. Splitting €200-450 across
+    three codes would mean inventing three prices the operator never quoted,
+    which is the one thing this parser must never do.
+    """
+    if not COMBINED_TAIL.search(label):
+        return False
+    return sum(1 for part in COMBINED_PARTS if part.search(label)) >= 2
+
+
 def classify_label(label: str) -> FeeCode | None:
     """Resolve one entry's label, or ``None`` when it is not a fee we know.
 
@@ -178,6 +225,10 @@ def classify_label(label: str) -> FeeCode | None:
         or NOT_A_LABEL.search(label)
     ):
         return None
+    # Ahead of the individual patterns, which would otherwise claim one
+    # component of a combined charge and drop the rest of its meaning.
+    if _combined_fee(label):
+        return FeeCode.COMBINED_FEES
     for pattern, code in COMPILED_LABELS:
         if pattern.search(label):
             return code
@@ -252,7 +303,27 @@ def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
         required = required_word.lower() == "required"
         for match in ENTRY.finditer(body):
             label = " ".join(match.group("label").split())
+
+            # The operator ends the list with a full stop, and everything after
+            # it is the rest of the page. Stored disclosures from six vessels
+            # show the real list running 55 to 273 characters inside a block
+            # that runs to 1500, closing "Snorkel Gear." or "Land Excursions."
+            # before the booking copy and the boat's feature list begin.
+            #
+            # Read before the entry is judged, not after, because the last
+            # genuine extra is often one we do not model: stopping only on
+            # recognised entries would let the whole page through behind an
+            # unrecognised "Snorkel Gear."
+            #
+            # This is what the label bounds below were standing in for. They
+            # stay as a second line of defence -- a page that never closes its
+            # list still must not mine prose -- but this one matches how the
+            # source is actually written.
+            last = match.group("end") == "."
+
             if not label or NOISE.match(label):
+                if last:
+                    break
                 continue
 
             # The block regex runs to the next heading or the end of the page,
@@ -270,6 +341,8 @@ def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
 
             code = classify_label(label)
             if code is None or code in seen:
+                if last:
+                    break
                 continue
             seen.add(code)
 
@@ -289,6 +362,9 @@ def parse_extras(text: str, default_currency: str = "EUR") -> list[ParsedFee]:
                     basis=basis,
                 )
             )
+
+            if last:
+                break
     return found
 
 

--- a/src/liveaboard/taxonomy.py
+++ b/src/liveaboard/taxonomy.py
@@ -64,6 +64,8 @@ class FeeCode(str, Enum):
     VISA = "visa"
     TAX_VAT = "tax_vat"
     ENVIRONMENT_TAX = "environment_tax"
+    SERVICE_CHARGE = "service_charge"
+    COMBINED_FEES = "combined_fees"
 
     NITROX = "nitrox"
     GEAR_RENTAL = "gear_rental"
@@ -79,6 +81,11 @@ class FeeCode(str, Enum):
     TANK_15L = "tank_15l"
     ALCOHOL = "alcohol"
     LAUNDRY = "laundry"
+    SNORKEL_GEAR = "snorkel_gear"
+    EXTRA_DIVES = "extra_dives"
+    LAND_EXCURSION = "land_excursion"
+    NATURALIST_GUIDE = "naturalist_guide"
+    NITROX_COURSE = "nitrox_course"
 
 
 TOGGLEABLE: dict[FeeCode, str] = {
@@ -99,6 +106,8 @@ FEE_LABELS: dict[FeeCode, str] = {
     FeeCode.VISA: "Egypt visa on arrival",
     FeeCode.TAX_VAT: "VAT / local tax",
     FeeCode.ENVIRONMENT_TAX: "Environment tax",
+    FeeCode.SERVICE_CHARGE: "Mandatory service charge",
+    FeeCode.COMBINED_FEES: "Park, port & fuel fees (billed together)",
     FeeCode.NITROX: "Nitrox",
     FeeCode.GEAR_RENTAL: "Equipment rental",
     FeeCode.DIVE_INSURANCE: "Dive insurance",
@@ -111,6 +120,11 @@ FEE_LABELS: dict[FeeCode, str] = {
     FeeCode.TANK_15L: "15 L tank",
     FeeCode.ALCOHOL: "Alcoholic drinks",
     FeeCode.LAUNDRY: "Laundry & pressing",
+    FeeCode.SNORKEL_GEAR: "Snorkel gear",
+    FeeCode.EXTRA_DIVES: "Extra dives",
+    FeeCode.LAND_EXCURSION: "Land excursions",
+    FeeCode.NATURALIST_GUIDE: "Naturalist / snorkelling guide",
+    FeeCode.NITROX_COURSE: "Nitrox course",
 }
 
 

--- a/tests/test_fees.py
+++ b/tests/test_fees.py
@@ -40,7 +40,8 @@ class TestRealDisclosure(unittest.TestCase):
         self.byc = by_code(self.fees)
 
     def test_every_extra_is_found(self):
-        self.assertEqual(len(self.fees), 10)
+        """Eleven: the two courses are separate priced lines, not one."""
+        self.assertEqual(len(self.fees), 11)
 
     def test_required_block_becomes_mandatory(self):
         for code in (
@@ -72,7 +73,12 @@ class TestRealDisclosure(unittest.TestCase):
 
     def test_nitrox_course_does_not_resolve_as_nitrox(self):
         self.assertEqual(self.byc[FeeCode.NITROX].low, 30.0)
-        self.assertEqual(self.byc[FeeCode.COURSE].low, 250.0)
+        self.assertEqual(self.byc[FeeCode.NITROX_COURSE].low, 250.0)
+
+    def test_the_two_courses_keep_their_own_prices(self):
+        """One code for both dropped whichever the page listed second."""
+        self.assertEqual(self.byc[FeeCode.NITROX_COURSE].low, 250.0)
+        self.assertEqual(self.byc[FeeCode.COURSE].low, 300.0)
 
     def test_gratuities_are_customary_despite_being_listed_optional(self):
         """The site's split says escapable; it does not say who actually escapes."""
@@ -94,7 +100,7 @@ class TestFeeDicts(unittest.TestCase):
         self.byc = {item.code: item for item in self.items}
 
     def test_dicts_load_as_fee_items(self):
-        self.assertEqual(len(self.items), 10)
+        self.assertEqual(len(self.items), 11)
 
     def test_range_survives_the_round_trip(self):
         park = self.byc[FeeCode.MARINE_PARK]
@@ -344,6 +350,162 @@ class TestDisclosureExcerpt(unittest.TestCase):
 
     def test_a_page_with_no_disclosure_yields_nothing(self):
         self.assertEqual(extras_excerpt("Boat Specifications Year built 2023"), {})
+
+
+# Verbatim from the stored disclosure of amelie, whose Optional block runs 273
+# characters of real list inside 1500 characters of page.
+AMELIE = (
+    "Optional Extras: Gratuities, Alcoholic Beverages, Extra Dives "
+    "(\u20ac50 / activity), Nitrox Course (\u20ac132), Private Dive Guide (\u20ac55), "
+    "Rental Gear, Scuba Diving Courses (\u20ac210-370), Land Excursions "
+    "(\u20ac35 / trip), Naturalist Guide (\u20ac50 / day), Snorkel Gear."
+    " Book now, pay later: You can easily place your booking online."
+    " Best Price Guaranteed, You're getting the lowest rate."
+    " Boat features, Free Internet, Jacuzzi / Hot Tub, Naturalist Guide,"
+    " Beer available, Wine Available, Bar, Nitrox, Library."
+)
+
+
+class TestListEndsAtTheFullStop(unittest.TestCase):
+    """The operator closes the list with a period; the page continues after it."""
+
+    def setUp(self):
+        self.fees = parse_extras(AMELIE)
+        self.byc = by_code(self.fees)
+
+    def test_every_extra_before_the_stop_is_captured(self):
+        for code in (
+            FeeCode.GRATUITIES, FeeCode.ALCOHOL, FeeCode.EXTRA_DIVES,
+            FeeCode.NITROX_COURSE, FeeCode.PRIVATE_GUIDE, FeeCode.GEAR_RENTAL,
+            FeeCode.COURSE, FeeCode.LAND_EXCURSION, FeeCode.NATURALIST_GUIDE,
+            FeeCode.SNORKEL_GEAR,
+        ):
+            self.assertIn(code, self.byc, code)
+
+    def test_nothing_after_the_stop_becomes_a_fee(self):
+        """"Bar", "Beer available" and "Nitrox" are amenities down there."""
+        self.assertNotIn(FeeCode.NITROX, self.byc)
+        self.assertNotIn(FeeCode.LAUNDRY, self.byc)
+
+    def test_the_stop_holds_on_an_extra_we_do_not_model(self):
+        """Breaking only on recognised entries let the whole page through."""
+        fees = parse_extras(
+            "Optional Extras: Gratuities, Yoga Sessions."
+            " Boat features, Nitrox, Bar, Free Internet, Laundry."
+        )
+        self.assertEqual([f.code for f in fees], [FeeCode.GRATUITIES])
+
+    def test_a_block_that_never_closes_still_stops(self):
+        """The label bounds remain the second line of defence."""
+        fees = parse_extras(
+            "Optional Extras: Gratuities, "
+            + "Pay by bank transfer or online with Best Price Guaranteed, " * 5
+        )
+        self.assertEqual([f.code for f in fees], [FeeCode.GRATUITIES])
+
+
+class TestExtrasWeUsedToDrop(unittest.TestCase):
+    """Six real entries the taxonomy had no code for, several of them priced."""
+
+    def test_alcohol_is_charged_on_every_vessel_seen(self):
+        self.assertEqual(classify_label("Alcoholic Beverages"), FeeCode.ALCOHOL)
+
+    def test_snorkel_gear_is_not_folded_into_rental_gear(self):
+        """One entry per code: folding them dropped whichever came second."""
+        fees = by_code(parse_extras(
+            "Optional Extras: Rental Gear, Snorkel Gear (\u20ac50)."
+        ))
+        self.assertIn(FeeCode.GEAR_RENTAL, fees)
+        self.assertEqual(fees[FeeCode.SNORKEL_GEAR].low, 50.0)
+
+    def test_the_rest_classify(self):
+        for text, code in (
+            ("Extra Dives", FeeCode.EXTRA_DIVES),
+            ("Land Excursions", FeeCode.LAND_EXCURSION),
+            ("Naturalist Guide", FeeCode.NATURALIST_GUIDE),
+            ("Snorkeling Guide", FeeCode.NATURALIST_GUIDE),
+        ):
+            self.assertEqual(classify_label(text), code, text)
+
+    def test_an_amenity_is_not_an_alcohol_charge(self):
+        """The feature list carries "Beer available" and "Wine Available"."""
+        self.assertIsNone(classify_label("Beer available"))
+        self.assertIsNone(classify_label("Wine Available"))
+
+    def test_a_naturalist_guide_is_not_a_private_dive_guide(self):
+        self.assertEqual(classify_label("Naturalist Guide"), FeeCode.NATURALIST_GUIDE)
+        self.assertEqual(classify_label("Private Dive Guide"), FeeCode.PRIVATE_GUIDE)
+
+    def test_the_new_codes_are_optional_so_no_default_total_moves(self):
+        """None is base, mandatory or customary, so DEFAULT_ON_TIERS is untouched."""
+        for fee in parse_extras(AMELIE):
+            if fee.code in (
+                FeeCode.SNORKEL_GEAR, FeeCode.EXTRA_DIVES,
+                FeeCode.LAND_EXCURSION, FeeCode.NATURALIST_GUIDE,
+                FeeCode.ALCOHOL, FeeCode.NITROX_COURSE,
+            ):
+                self.assertEqual(fee.tier, FeeTier.OPTIONAL, fee.code)
+
+
+class TestMandatoryFeesNoOneNamed(unittest.TestCase):
+    """Required-block charges the parser had no code for, so it dropped them.
+
+    Understating a bill is the same failure as inventing one, told the other
+    way round -- and it also flatters the honesty score, because a fee that
+    never reaches the breakdown cannot count against the operator.
+    """
+
+    AVO = (
+        "Required Extras: Mandatory Service Charge (\u20ac80), "
+        "Park, Port and Fuel Fees (\u20ac200-450 / trip)."
+    )
+
+    def test_a_whole_required_block_is_no_longer_lost(self):
+        """This vessel published two mandatory charges and we showed neither."""
+        fees = parse_extras(self.AVO)
+        self.assertEqual(len(fees), 2)
+        self.assertTrue(all(f.tier is FeeTier.MANDATORY for f in fees))
+
+    def test_the_service_charge_is_captured(self):
+        byc = by_code(parse_extras(self.AVO))
+        self.assertEqual(byc[FeeCode.SERVICE_CHARGE].low, 80.0)
+
+    def test_a_combined_charge_keeps_its_whole_amount(self):
+        """Splitting it across three codes would invent three prices."""
+        byc = by_code(parse_extras(self.AVO))
+        combined = byc[FeeCode.COMBINED_FEES]
+        self.assertEqual((combined.low, combined.high), (200.0, 450.0))
+        self.assertTrue(combined.is_range)
+
+    def test_two_components_make_a_combined_charge(self):
+        for label in ("Park, Port and Fuel Fees", "Park and Port Fees",
+                      "Port and Fuel Fees"):
+            self.assertEqual(classify_label(label), FeeCode.COMBINED_FEES, label)
+
+    def test_one_component_stays_its_own_fee(self):
+        """The combined check must not swallow the ordinary single lines."""
+        for label, code in (
+            ("National Park Fees", FeeCode.MARINE_PARK),
+            ("Port Fees", FeeCode.PORT_FEES),
+            ("Fuel Surcharge", FeeCode.FUEL_SURCHARGE),
+            ("Environment Tax", FeeCode.ENVIRONMENT_TAX),
+            ("Harbour Dues", FeeCode.PORT_FEES),
+        ):
+            self.assertEqual(classify_label(label), code, label)
+
+    def test_a_bare_component_with_no_fee_word_is_not_a_charge(self):
+        """"Park" alone is the comma-split remains of the label above it."""
+        self.assertIsNone(classify_label("Park"))
+
+    def test_separately_billed_fees_are_still_separate(self):
+        fees = by_code(parse_extras(
+            "Required Extras: Mandatory Service Charge (\u20ac10 / day), "
+            "National Park Fees (\u20ac10 / day), Port Fees (\u20ac5 / trip)."
+        ))
+        self.assertEqual(
+            set(fees),
+            {FeeCode.SERVICE_CHARGE, FeeCode.MARINE_PARK, FeeCode.PORT_FEES},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Storing the disclosure text (previous PR) made it possible to audit the parser against **twelve vessels' real text with no browser run**. This is what that audit found.

## Mandatory charges we had no name for

Four of twelve vessels published a required block that we rendered as **empty**. `avo` lists:

```
Required Extras: Mandatory Service Charge (€80),
                 Park, Port and Fuel Fees (€200-450 / trip).
```

and reached the site with **no mandatory fees at all** — €280 to €530 of unavoidable cost shown as nothing. Understating a bill is the same failure as inventing one, told the other way round. It also flatters the honesty score: a fee that never reaches the breakdown cannot count against the operator.

Two causes. `Mandatory Service Charge` had no code (3 of 12 vessels). And `Park, Port and Fuel Fees` splits on its own comma, leaving `Park` and `Port and Fuel Fees` — neither half puts "port" adjacent to "fees", so nothing matched.

It now resolves as **one line carrying the whole amount**. Splitting €200-450 across three codes would mean inventing three prices the operator never quoted, which is the one thing this parser must never do. A label naming two or more of park / port / fuel / environment alongside a fee word is combined; a single component still resolves to its own code, so `National Park Fees` and `Port Fees` are unaffected.

| vessel | mandatory before | after |
| --- | --- | --- |
| aphrodite | *none* | `combined_fees €150` |
| ashrafi | *none* | `combined_fees €145` |
| avo | *none* | `service_charge €80`, `combined_fees €200-450` |
| bismarck | *none* | `service_charge €120`, `combined_fees €130` |

## Optional extras with no code

Six real entries dropped from every vessel that listed them, several priced: **Alcoholic Beverages** (all 12), Snorkel Gear, Extra Dives, Land Excursions, Naturalist Guide. `Nitrox Course` and `Scuba Diving Courses` shared one code, so whichever the page listed second was discarded.

All are **optional** tier — no default total moves, and `DEFAULT_ON_TIERS` is untouched, so no `app.js` change.

## The list ends where the operator ends it

Every disclosure closes with a full stop and then runs on into booking copy and the boat's feature list — **55 to 273 characters of real list inside a 1500-character block**. Stopping there is what `MAX_LABEL_CHARS` / `MAX_LABEL_WORDS` were standing in for; they remain as a second line of defence for a block that never closes.

The stop is read *before* the entry is judged, because the last genuine extra is often one we don't model — breaking only on recognised entries let the whole feature list through behind an unrecognised `Snorkel Gear.` (and that list contains "Nitrox", "Bar" and "Beer available").

## Result

Across the twelve vessels: **65 fee lines → 109**, every vessel now carries its mandatory charges, and no fabrication returns. 185 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_