### PR TITLE
Guard that every fee code can be named on the page

### DIFF
--- a/tests/test_fees.py
+++ b/tests/test_fees.py
@@ -508,5 +508,22 @@ class TestMandatoryFeesNoOneNamed(unittest.TestCase):
         )
 
 
+class TestEveryCodeCanBeNamed(unittest.TestCase):
+    """render.py hands FEE_LABELS to the page as the only source of names."""
+
+    def test_no_code_would_render_as_its_slug(self):
+        from liveaboard.taxonomy import FEE_LABELS
+
+        missing = sorted(c.value for c in FeeCode if c not in FEE_LABELS)
+        self.assertEqual(missing, [], f"unnamed fee codes: {missing}")
+
+    def test_every_code_the_parser_can_emit_has_a_label(self):
+        from liveaboard.scrape.fees import LABEL_PATTERNS
+        from liveaboard.taxonomy import FEE_LABELS
+
+        for _, code in LABEL_PATTERNS:
+            self.assertIn(code, FEE_LABELS, code)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`render.py` hands `FEE_LABELS` to the browser as the only source of fee names, so a code added without one renders as its raw slug (`combined_fees`) in the breakdown.

Seven codes were added today across two PRs and nothing would have caught the omission. Two tests now do: every `FeeCode` has a label, and every code the parser can emit has one.

187 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_