### PR TITLE
Publish when the renderer changes, not only the data

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,8 +16,17 @@ name: Publish site
 on:
   push:
     branches: [main]
+    # The job rebuilds the page from the dataset rather than publishing the
+    # committed HTML, so anything that changes what `cli build` emits belongs
+    # here. Watching site/** alone meant a fix to the template or the renderer
+    # never reached the live page: the commit changed no file under site/, so
+    # nothing fired, and the deployed HTML kept whatever the last data commit
+    # happened to build.
     paths:
       - "site/**"
+      - "templates/**"
+      - "src/**"
+      - "data/**"
       - ".github/workflows/pages.yml"
   workflow_run:
     workflows: ["Daily refresh", "Weekly fee refresh"]


### PR DESCRIPTION
The deploy job rebuilds the page from the dataset rather than publishing the committed HTML — but its push trigger watched only `site/**`.

So a fix to `templates/app.js` or to `render.py` changes no file under `site/`, nothing fires, and the live page keeps whatever the last *data* commit happened to build. The FX caveat merged in #28 would have sat unpublished until an unrelated scrape overwrote the page.

Same shape as the `workflow_run` bug fixed earlier: the trigger didn't match what the job actually consumes. Now it watches everything that changes what `cli build` emits — `templates/**`, `src/**` and `data/**` alongside `site/**`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_