### PR TITLE
Do not score an operator honest for disclosing nothing

### DIFF
--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from .classify import classify
 from .dataset import Dataset, DatasetError
-from .pricing import compute, resolve_fees, transparency_score
+from .pricing import compute, mandatory_known, resolve_fees, transparency_score
 from .promote import promote
 from .render import render
 from .scrape.base import FetchBlocked, PoliteFetcher, ScrapeOutput
@@ -66,9 +66,12 @@ def cmd_check(args: argparse.Namespace) -> int:
             continue
         first = departures[0]
         breakdown = compute(itinerary, first, dataset.fx)
-        # Same rule as the rendered page: no fee lines means nobody has looked,
-        # not that the advertised price is the whole bill.
-        known = bool(resolve_fees(itinerary, first))
+        # Same rule as the rendered page. No fee lines means nobody has
+        # looked; only optional ones means the operator did not state its
+        # unavoidable costs. Neither means the advertised price is the whole
+        # bill, and scoring them as if it were ranked the least forthcoming
+        # operators highest.
+        known = bool(resolve_fees(itinerary, first)) and mandatory_known(itinerary, first)
         if not known:
             unknown += 1
         rows.append(
@@ -93,7 +96,10 @@ def cmd_check(args: argparse.Namespace) -> int:
             )
 
     if unknown:
-        print(f"\n  {unknown} of {len(rows)} itineraries have no fee data captured yet")
+        print(
+            f"\n  {unknown} of {len(rows)} itineraries have no stated mandatory "
+            f"fees, so no true cost or honesty score is claimed for them"
+        )
 
     print()
     for key, itinerary in dataset.itineraries.items():

--- a/src/liveaboard/pricing.py
+++ b/src/liveaboard/pricing.py
@@ -224,6 +224,27 @@ def resolve_fees(itinerary: Itinerary, departure: Departure) -> list[FeeItem]:
     return list(merged.values())
 
 
+def mandatory_known(itinerary: Itinerary, departure: Departure) -> bool:
+    """Has the operator said anything about its unavoidable costs?
+
+    Seven of seventy-nine vessels publish an extras disclosure listing only
+    optional items — gratuities, gear, courses — and no required block at all.
+    Every Egyptian liveaboard pays marine park and port fees, so that silence
+    means one of two things and does not say which: the fees are bundled into
+    the fare, or they are collected at the dock and simply not advertised.
+
+    Counting the silence as zero made the site rank those operators as its most
+    honest: ``odyssey`` scored 96% and ``emperor-asmaa`` 93%, against 86% for a
+    vessel that published its park and port fees in full. A page built to argue
+    that advertised prices hide costs cannot reward the operators that disclose
+    the least.
+
+    An *included* mandatory line still counts as known — that is an operator
+    stating the fee is in the fare, which is the honest case this rewards.
+    """
+    return any(fee.tier is FeeTier.MANDATORY for fee in resolve_fees(itinerary, departure))
+
+
 def _is_counted(fee: FeeItem, toggles: Toggles) -> bool:
     """Whether this fee lands in the total under the given toggles."""
     if fee.tier is FeeTier.OPTIONAL:

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -20,7 +20,13 @@ from typing import Any
 from .classify import classify, themes_in_season
 from .dataset import Dataset
 from .money import DISPLAY_CURRENCY
-from .pricing import DEFAULT_TOGGLES, compute, resolve_fees, transparency_score
+from .pricing import (
+    DEFAULT_TOGGLES,
+    compute,
+    mandatory_known,
+    resolve_fees,
+    transparency_score,
+)
 from .taxonomy import (
     DIVER_LEVEL_LABELS,
     DIVER_LEVEL_ORDER,
@@ -89,11 +95,16 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
         # advertised price, and a perfect honesty score, would make this site
         # commit exactly the omission it exists to expose.
         fees_known = bool(resolve_fees(itinerary, departure))
+        # Listing only optional extras is not the same as having no required
+        # ones, and scoring it as such put the least forthcoming operators at
+        # the top of the honesty ranking. See pricing.mandatory_known.
+        mandatory = mandatory_known(itinerary, departure)
 
         departures.append(
             {
                 "id": departure.id,
                 "fees_known": fees_known,
+                "mandatory_known": mandatory,
                 "itinerary_id": itinerary.id,
                 "boat_id": itinerary.boat_id,
                 "start": departure.start.isoformat(),
@@ -106,7 +117,7 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
                 "lines": [line.as_dict() for line in breakdown.lines],
                 "transparency": (
                     round(transparency_score(itinerary, departure, dataset.fx), 4)
-                    if fees_known
+                    if fees_known and mandatory
                     else None
                 ),
                 "peak_themes": [t.value for t in themes_in_season(themes, departure.start.month)],

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -108,6 +108,11 @@ NON_BOAT_SLUGS = frozenset(
         "straits-of-tiran", "abu-nuhas", "daedalus", "elphinstone", "st-johns",
         "abu-dabab", "brothers-islands", "daedalus-reef", "fury-shoal", "tiran",
         "sharm-el-sheikh", "hurghada", "marsa-alam", "port-ghalib", "safaga",
+        # Found by a full 79-vessel run: these reached the fee collector and
+        # came back as vessels it had failed on, which is a different thing
+        # from a boat whose disclosure could not be read.
+        "gordon-reef", "jackson-reef", "woodhouse-reef", "shark-and-yolanda",
+        "salem-express", "hamata", "sinai", "rocky", "dahab",
         # Site furniture.
         "liveaboards", "reviews", "deals",
     }

--- a/templates/app.js
+++ b/templates/app.js
@@ -214,10 +214,26 @@
       advertised.appendChild(el("span", "was", "advertised " + euro.format(dep.base)));
       advertised.appendChild(document.createTextNode(" · "));
       advertised.appendChild(el("span", "markup", "+" + Math.round(m.markup) + "%"));
-    } else {
+    } else if (dep.mandatory_known) {
       advertised.appendChild(el("span", "markup none", "no extras to add"));
+    } else {
+      /* "No extras to add" would claim the operator charges none. It only
+         published optional ones. */
+      advertised.appendChild(el("span", "markup none", "no required extras listed"));
     }
     block.appendChild(advertised);
+
+    /* The operator listed extras, but none of them required. Every Egyptian
+       liveaboard pays park and port fees, so that silence means either that
+       they are bundled into the fare or that they are collected at the dock
+       unadvertised — and it does not say which. Scoring it as a clean bill
+       put the least forthcoming operators at the top of the ranking. */
+    if (!dep.mandatory_known) {
+      block.appendChild(el("div", "honesty-unknown",
+        "Operator lists no required extras — park and port fees may be " +
+        "bundled, or charged at the dock"));
+      return block;
+    }
 
     var honesty = el("div", "honesty");
     honesty.appendChild(el("span", "honesty-label", "Honesty "));
@@ -300,7 +316,10 @@
     });
 
     var totalRow = el("tr", "total");
-    totalRow.appendChild(el("td", null, dep.fees_known ? "True cost" : "Advertised price"));
+    totalRow.appendChild(el("td", null,
+      !dep.fees_known ? "Advertised price"
+        : dep.mandatory_known ? "True cost"
+                              : "Advertised price plus listed extras"));
     totalRow.appendChild(el("td"));
     totalRow.appendChild(el("td"));
     totalRow.appendChild(el("td", "num", "€" + formatSpan(m)));
@@ -316,12 +335,17 @@
       body.appendChild(extra);
     }
 
-    if (!dep.fees_known) {
+    if (!dep.fees_known || !dep.mandatory_known) {
       var caveat = el("tr");
       var cell = el("td", "fee-note",
-        "Marine park fees, port dues, fuel, nitrox and gratuities are not " +
-        "included above because they have not been captured for this trip yet. " +
-        "On comparable trips they add 30–60%.");
+        !dep.fees_known
+          ? "Marine park fees, port dues, fuel, nitrox and gratuities are not " +
+            "included above because they have not been captured for this trip yet. " +
+            "On comparable trips they add 30–60%."
+          : "This operator publishes no required extras. Every Egyptian liveaboard " +
+            "pays marine park and port fees, so either they are already inside the " +
+            "advertised price or they are collected at the dock — the listing does " +
+            "not say which, so no true cost is claimed here.");
       cell.colSpan = 4;
       caveat.appendChild(cell);
       body.appendChild(caveat);

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -12,7 +12,15 @@ from decimal import Decimal
 
 from liveaboard.models import Departure, FeeItem, Itinerary, Provenance
 from liveaboard.money import FxTable, Money
-from liveaboard.pricing import REFERENCE_BASKET, compute, resolve_fees, transparency_score
+from liveaboard.dataset import Dataset
+from liveaboard.pricing import (
+    REFERENCE_BASKET,
+    compute,
+    mandatory_known,
+    resolve_fees,
+    transparency_score,
+)
+from liveaboard.render import build_payload
 from liveaboard.taxonomy import FeeBasis, FeeCode, FeeTier, SourceKind
 
 FX = FxTable.from_dict(
@@ -209,6 +217,98 @@ class TestTransparencyScore(unittest.TestCase):
             transparency_score(bundled, dear, FX),
             transparency_score(hidden, cheap, FX),
         )
+
+
+class TestOnlyOptionalExtrasIsNotACleanBill(unittest.TestCase):
+    """Seven of seventy-nine vessels publish optional extras and no required ones.
+
+    Counting that silence as zero made the site rank them as its most honest
+    operators: odyssey scored 96% and emperor-asmaa 93%, against 86% for a
+    vessel that published its park and port fees in full.
+    """
+
+    PROV = {"kind": "scraped", "source_id": "liveaboard.com", "retrieved": "2026-08-27"}
+
+    def dataset(self, fees):
+        return Dataset.from_dict({
+            "schema_version": 1, "generated": "2026-08-27", "default_currency": "EUR",
+            "notes": "t",
+            "fx": {"display_currency": "EUR", "as_of": "2026-08-27",
+                   "source": "test", "rates": {"USD": 0.92}},
+            "operators": [{"id": "o", "name": "O"}],
+            "boats": [{"id": "b", "name": "B", "operator_id": "o"}],
+            "itineraries": [{
+                "id": "i", "name": "I", "operator_id": "o", "boat_id": "b",
+                "nights": 7, "dives": 0, "port_from": "Hurghada",
+                "port_to": "Hurghada", "dive_sites": ["brothers"], "fees": fees,
+            }],
+            "departures": [{
+                "id": "d", "itinerary_id": "i", "start": "2027-05-01",
+                "end": "2027-05-08", "price": {"amount": 1500.0, "currency": "EUR"},
+                "provenance": self.PROV,
+            }],
+        })
+
+    def fee(self, code, tier, amount=100.0, included=False):
+        entry = {"code": code, "tier": tier, "basis": "per_trip",
+                 "included": included, "provenance": self.PROV}
+        entry["amount"] = {"amount": amount, "currency": "EUR"} if amount else None
+        return entry
+
+    def parts(self, fees):
+        d = self.dataset(fees)
+        itinerary = next(iter(d.itineraries.values()))
+        return itinerary, d.departures[0], d
+
+    def test_optional_extras_alone_leave_the_mandatory_picture_unknown(self):
+        itinerary, departure, _ = self.parts([
+            self.fee("gratuities", "customary"),
+            self.fee("gear_rental", "conditional", None),
+            self.fee("course", "optional", 250.0),
+        ])
+        self.assertFalse(mandatory_known(itinerary, departure))
+
+    def test_one_required_line_is_enough_to_know(self):
+        itinerary, departure, _ = self.parts([self.fee("marine_park", "mandatory", 80.0)])
+        self.assertTrue(mandatory_known(itinerary, departure))
+
+    def test_a_bundled_fee_still_counts_as_stated(self):
+        """An operator saying "it is in the fare" is the honest case."""
+        itinerary, departure, _ = self.parts([
+            self.fee("marine_park", "mandatory", 0.0, included=True),
+        ])
+        self.assertTrue(mandatory_known(itinerary, departure))
+
+    def test_the_page_withholds_the_score_rather_than_awarding_it(self):
+        payload = build_payload(self.dataset([
+            self.fee("gratuities", "customary"),
+            self.fee("course", "optional", 250.0),
+        ]))
+        rendered = payload["departures"][0]
+        self.assertFalse(rendered["mandatory_known"])
+        self.assertIsNone(rendered["transparency"])
+
+    def test_a_disclosing_operator_still_gets_scored(self):
+        payload = build_payload(self.dataset([
+            self.fee("marine_park", "mandatory", 150.0),
+            self.fee("gratuities", "customary"),
+        ]))
+        rendered = payload["departures"][0]
+        self.assertTrue(rendered["mandatory_known"])
+        self.assertIsNotNone(rendered["transparency"])
+
+    def test_silence_no_longer_outranks_disclosure(self):
+        """The regression in one line: quiet operator vs forthcoming one."""
+        quiet = build_payload(self.dataset([
+            self.fee("gratuities", "customary"),
+        ]))["departures"][0]
+        forthcoming = build_payload(self.dataset([
+            self.fee("marine_park", "mandatory", 150.0),
+            self.fee("port_fees", "mandatory", 80.0),
+            self.fee("gratuities", "customary"),
+        ]))["departures"][0]
+        self.assertIsNone(quiet["transparency"])
+        self.assertIsNotNone(forthcoming["transparency"])
 
 
 if __name__ == "__main__":

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -49,11 +49,18 @@ class TestBoatLinks(unittest.TestCase):
         self.assertEqual(len(self.found), 2)
 
     def test_rejects_the_dive_sites_the_search_page_actually_links(self):
-        """Taken verbatim from a live search page's destination nav."""
+        """Taken verbatim from a live search page's destination nav.
+
+        The second group came back from a full 79-vessel fee run listed as
+        vessels it had failed on -- Gordon, Jackson and Woodhouse are reefs in
+        the Straits of Tiran and the Salem Express is a wreck.
+        """
         sites = [
             "red-sea", "thistlegorm", "ras-mohammed", "the-brothers",
             "straits-of-tiran", "abu-nuhas", "daedalus", "elphinstone",
             "st-johns", "abu-dabab",
+            "gordon-reef", "jackson-reef", "woodhouse-reef",
+            "shark-and-yolanda", "salem-express", "hamata", "sinai", "rocky",
         ]
         html = "".join(f'<a href="/diving/egypt/{slug}">x</a>' for slug in sites)
         self.assertEqual(LiveaboardComAdapter.boat_links(html), set())


### PR DESCRIPTION
Collecting fees for all 79 vessels turned up **seven that publish an extras disclosure listing only optional items** — gratuities, gear, courses — and no required block at all.

The engine read that silence as zero mandatory fees and scored them accordingly:

| vessel | required extras published | honesty |
| --- | --- | --- |
| `odyssey` | none | **96%** |
| `emperor-asmaa` | none | **93%** |
| `alia-soul` | environment tax €24/night, port fees €80 | 86% |
| `avo` | service charge €80, park/port/fuel €200-450 | 84% |

The site was **ranking the operators that disclosed the least as its most transparent** — the exact claim it exists to challenge. `fees_known` didn't catch it: these vessels *do* have fee lines, six of them, just none required.

## The rule

Every Egyptian liveaboard pays marine park and port fees. A listing that names none means either they're bundled into the fare or collected at the dock unadvertised, and it does not say which. So no true cost and no honesty score are claimed for those vessels.

An **included** mandatory line still counts as stated — an operator saying the fee is in the fare is the honest case, and it keeps its score.

The page explains rather than showing a bare dash:

> Operator lists no required extras — park and port fees may be bundled, or charged at the dock

and in the breakdown: *"…either they are already inside the advertised price or they are collected at the dock — the listing does not say which, so no true cost is claimed here."* The summary line changes from "no extras to add" (a claim about the operator) to "no required extras listed" (a claim about the listing).

After: `odyssey` and `emperor-asmaa` withheld; `alia-soul` 86%, `avo` 84%.

## Also

Nine more dive-site slugs the full run walked into — Gordon, Jackson and Woodhouse are reefs in the Straits of Tiran, the Salem Express is a wreck. They were landing in the fee book's `missing` list, which should mean *a boat whose disclosure could not be read*, not a reef. Left as it was, a real coverage failure would have hidden among nine permanent false entries.

197 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_