### PR TITLE
Compare what trips cost; stop grading who sells them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,12 @@ Break these and the site starts lying quietly rather than failing loudly.
   are switched on. Do not add pricing logic to the JS.
 - **Included fees stay in the breakdown at zero.** Removing them hides the
   difference between a bundled operator and one that bills at the dock.
-- **The honesty score uses `REFERENCE_BASKET`, never the visitor's toggles.**
-  It describes the operator's pricing, not the person looking.
+- **No score grading operators.** The site compares what trips cost; it does
+  not rank who sells them. A per-operator "honesty" percentage was removed:
+  it read as a league table and contradicted the total beside it.
+- **Never claim a total the disclosure does not support.** No fee lines means
+  nobody looked; only optional ones means the operator did not state its
+  required extras. Neither is a clean bill.
 - **Classification derives from dive sites**, not from trip names. An explicit
   value in the dataset wins; a stated safety requirement is never softened.
 - **Zero runtime dependencies**, stdlib only, and the site stays one

--- a/README.md
+++ b/README.md
@@ -77,10 +77,15 @@ PYTHONPATH=src python3 -m unittest discover -s tests
 A fee an operator **includes** still appears in the breakdown, at zero —
 deleting it would hide the exact difference this site exists to show.
 
-**Honesty score**: what share of the bill the headline discloses, measured
-against a fixed basket rather than the visitor's toggles, so it describes the
-operator rather than the visitor. Two boats can reach the same true cost and
-score 60% vs 83%.
+**Comparison, not a scoreboard**: the lists sort by true cost, cost per night,
+advertised price, and how much lands after the headline figure. There is no
+per-operator rating — two boats reaching the same true cost by different routes
+show that in their breakdowns, which is the part a diver can act on.
+
+**Unstated is not zero**: a vessel listing only optional extras gets no true
+cost at all. Every Egyptian liveaboard pays park and port fees, so silence
+means either bundled or collected at the dock, and the listing does not say
+which.
 
 **Classification** is derived from each trip's dive-site list, not from operator
 marketing, so "Simply the Best", "Ultimate Red Sea" and "BDE" get one label.

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from .classify import classify
 from .dataset import Dataset, DatasetError
-from .pricing import compute, mandatory_known, resolve_fees, transparency_score
+from .pricing import compute, mandatory_known, resolve_fees
 from .promote import promote
 from .render import render
 from .scrape.base import FetchBlocked, PoliteFetcher, ScrapeOutput
@@ -58,7 +58,7 @@ def cmd_check(args: argparse.Namespace) -> int:
     print(f"  sources: {', '.join(sorted(k.value for k in dataset.source_kinds))}")
     print()
 
-    rows: list[tuple[str, float, float, float | None, float | None]] = []
+    rows: list[tuple[str, float, float, float | None]] = []
     unknown = 0
     for key, itinerary in dataset.itineraries.items():
         departures = [d for d in dataset.departures if d.itinerary_id == key]
@@ -80,19 +80,18 @@ def cmd_check(args: argparse.Namespace) -> int:
                 float(breakdown.base.rounded),
                 float(breakdown.total.rounded),
                 breakdown.markup_pct if known else None,
-                transparency_score(itinerary, first, dataset.fx) * 100 if known else None,
             )
         )
 
     width = min(max((len(r[0]) for r in rows), default=20), 44)
-    print(f"  {'itinerary'.ljust(width)}  {'advertised':>11} {'true cost':>10} {'markup':>8} {'honesty':>8}")
-    for name, base, total, markup, honesty in sorted(rows, key=lambda r: -(r[3] or -1)):
+    print(f"  {'itinerary'.ljust(width)}  {'advertised':>11} {'true cost':>10} {'lands later':>12}")
+    for name, base, total, markup in sorted(rows, key=lambda r: -(r[3] or -1)):
         if markup is None:
-            print(f"  {name[:width].ljust(width)}  {base:>11,.0f} {'unknown':>10} {'—':>8} {'—':>8}")
+            print(f"  {name[:width].ljust(width)}  {base:>11,.0f} {'unknown':>10} {'—':>12}")
         else:
             print(
                 f"  {name[:width].ljust(width)}  {base:>11,.0f} {total:>10,.0f} "
-                f"{markup:>7.0f}% {honesty:>7.0f}%"
+                f"{total - base:>7,.0f} ({markup:>2.0f}%)"
             )
 
     if unknown:

--- a/src/liveaboard/pricing.py
+++ b/src/liveaboard/pricing.py
@@ -3,16 +3,17 @@
 Given a departure and a set of visitor toggles, produce the full stack of what
 a diver actually pays, in euro, with every line attributable to a source.
 
-Two design decisions are load-bearing:
+One design decision is load-bearing: **included fees still appear**, at zero
+additional cost. An operator that bundles marine park fees should be visibly
+different from one that bills at the dock, and deleting the line would hide
+exactly the difference the site exists to show.
 
-1. **Included fees still appear**, at zero additional cost. An operator that
-   bundles marine park fees should be visibly rewarded for it, and deleting the
-   line would hide exactly the difference the site exists to show.
-
-2. **The transparency score is computed against a fixed reference basket**, not
-   against the visitor's live toggles. A score that moved every time someone
-   flicked "nitrox" would rank operators by the visitor's mood rather than by
-   how much of the real cost they disclose up front.
+This module deliberately produces no score. It used to derive an "honesty"
+percentage per operator, which turned the page into a league table and, worse,
+disagreed with the total beside it: the score was measured against a fixed
+basket while the total followed the visitor's own toggles. Two numbers about
+the same trip, contradicting each other. What a diver needs is what the trip
+costs them, so that is all this returns.
 """
 
 from __future__ import annotations
@@ -39,21 +40,6 @@ DEFAULT_TOGGLES: dict[str, bool] = {
 Transfers and gratuities default on because almost nobody actually skips them;
 nitrox and gear default off because plenty of divers bring their own.
 """
-
-REFERENCE_BASKET: dict[str, bool] = {
-    "nitrox": True,
-    "gear": True,
-    "insurance": True,
-    "transfers": True,
-    "gratuities": True,
-}
-"""The fixed basket the transparency score is measured against.
-
-Deliberately the most inclusive reading: every conditional cost a typical diver
-could face. It makes the score a property of the operator's pricing, not of the
-person looking at it.
-"""
-
 
 @dataclass(frozen=True, slots=True)
 class BreakdownLine:
@@ -328,16 +314,3 @@ def _sorted_fees(fees: Iterable[FeeItem]) -> list[FeeItem]:
     return sorted(fees, key=lambda f: (_TIER_ORDER[f.tier], f.code.value))
 
 
-def transparency_score(itinerary: Itinerary, departure: Departure, fx: FxTable) -> float:
-    """Fraction of the reference-basket cost that the headline price discloses.
-
-    ``1.0`` means the advertised number is the whole bill. ``0.7`` means three
-    euro in every ten arrive later, at the dock or on the final invoice.
-    """
-    reference = compute(itinerary, departure, fx, REFERENCE_BASKET)
-    total = reference.total.amount
-    if total <= 0:
-        return 1.0
-    # Bundled fees need no separate credit here: they are already inside the
-    # advertised price, which is precisely why that price is more honest.
-    return min(1.0, float(reference.base.amount / total))

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -20,13 +20,7 @@ from typing import Any
 from .classify import classify, themes_in_season
 from .dataset import Dataset
 from .money import DISPLAY_CURRENCY
-from .pricing import (
-    DEFAULT_TOGGLES,
-    compute,
-    mandatory_known,
-    resolve_fees,
-    transparency_score,
-)
+from .pricing import DEFAULT_TOGGLES, compute, mandatory_known, resolve_fees
 from .taxonomy import (
     DIVER_LEVEL_LABELS,
     DIVER_LEVEL_ORDER,
@@ -115,11 +109,6 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
                 "booking_url": departure.booking_url,
                 "base": float(breakdown.base.rounded),
                 "lines": [line.as_dict() for line in breakdown.lines],
-                "transparency": (
-                    round(transparency_score(itinerary, departure, dataset.fx), 4)
-                    if fees_known and mandatory
-                    else None
-                ),
                 "peak_themes": [t.value for t in themes_in_season(themes, departure.start.month)],
                 "verified": departure.price_provenance.is_verified,
             }

--- a/templates/app.js
+++ b/templates/app.js
@@ -105,12 +105,12 @@
     true_cost: function (a, b) { return metricsFor(a).total - metricsFor(b).total; },
     per_night: function (a, b) { return metricsFor(a).perNight - metricsFor(b).perNight; },
     base: function (a, b) { return a.base - b.base; },
-    markup: function (a, b) { return metricsFor(b).markup - metricsFor(a).markup; },
-    /* Departures with no fee data sort last rather than winning on a score
-       they were never given. */
-    transparency: function (a, b) {
-      var x = a.transparency === null ? -1 : a.transparency;
-      var y = b.transparency === null ? -1 : b.transparency;
+    /* Biggest surprise first: how much lands after the headline price.
+       Trips whose required extras are unstated sort last -- there is no gap
+       to report, and putting them first would read as "nothing to add". */
+    later: function (a, b) {
+      var x = a.mandatory_known ? metricsFor(a).surcharge : -1;
+      var y = b.mandatory_known ? metricsFor(b).surcharge : -1;
       return y - x;
     }
   };
@@ -158,10 +158,6 @@
     return a + " – " + b;
   }
 
-  function honestyClass(score) {
-    return score >= 0.85 ? "good" : score >= 0.7 ? "mid" : "bad";
-  }
-
   function labelFor(list, id) {
     for (var i = 0; i < list.length; i++) if (list[i].id === id) return list[i].label;
     return id;
@@ -199,13 +195,12 @@
     }
 
     /* Without fee data there is no true cost to report. Saying "no extras to
-       add" would claim we checked, and claiming a perfect honesty score would
-       reward an operator for our own missing homework. */
+       add" would claim we checked when nobody has. */
     if (!dep.fees_known) {
       var unknown = el("div", "advertised");
       unknown.appendChild(el("span", "unknown", "advertised price only"));
       block.appendChild(unknown);
-      block.appendChild(el("div", "honesty-unknown", "Extra fees not yet captured"));
+      block.appendChild(el("div", "cost-unknown", "Extra fees not yet captured"));
       return block;
     }
 
@@ -226,24 +221,13 @@
     /* The operator listed extras, but none of them required. Every Egyptian
        liveaboard pays park and port fees, so that silence means either that
        they are bundled into the fare or that they are collected at the dock
-       unadvertised — and it does not say which. Scoring it as a clean bill
-       put the least forthcoming operators at the top of the ranking. */
+       unadvertised — and it does not say which, so no total is claimed. */
     if (!dep.mandatory_known) {
-      block.appendChild(el("div", "honesty-unknown",
+      block.appendChild(el("div", "cost-unknown",
         "Operator lists no required extras — park and port fees may be " +
         "bundled, or charged at the dock"));
       return block;
     }
-
-    var honesty = el("div", "honesty");
-    honesty.appendChild(el("span", "honesty-label", "Honesty "));
-    honesty.appendChild(el("span", "honesty-value", Math.round(dep.transparency * 100) + "%"));
-    var bar = el("div", "honesty-bar");
-    var fill = el("div", "honesty-fill " + honestyClass(dep.transparency));
-    fill.style.width = Math.round(dep.transparency * 100) + "%";
-    bar.appendChild(fill);
-    honesty.appendChild(bar);
-    block.appendChild(honesty);
 
     return block;
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,8 +43,8 @@
           <option value="true_cost">True cost, lowest first</option>
           <option value="per_night">Cost per night</option>
           <option value="base">Advertised price</option>
-          <option value="markup">Biggest gap to advertised price</option>
-          <option value="transparency">Most honest pricing</option>
+          <option value="markup">Biggest gap, as a percentage</option>
+          <option value="later">Most money landing after the headline price</option>
         </select>
       </div>
     </div>
@@ -101,12 +101,12 @@
         </p>
       </div>
       <div>
-        <h3>Honesty score</h3>
+        <h3>What lands later</h3>
         <p>
-          What share of the full bill the advertised price actually discloses,
-          measured against a fixed basket of every conditional cost. It is a
-          property of the operator's pricing, so it does not move when you change
-          the toggles.
+          The gap between the advertised price and what you actually pay, in euro
+          and as a percentage. Sort by it to see which trips hold back the most.
+          There is no rating of operators here: two boats can reach the same true
+          cost by pricing very differently, and the breakdown shows how.
         </p>
       </div>
       <div>

--- a/templates/style.css
+++ b/templates/style.css
@@ -270,7 +270,7 @@ select {
 
 .advertised .unknown { color: var(--text-faint); font-style: italic; }
 
-.honesty-unknown {
+.cost-unknown {
   margin-top: 8px;
   padding: 3px 8px;
   display: inline-block;
@@ -281,14 +281,6 @@ select {
   border-radius: var(--radius-sm);
 }
 
-.honesty { margin-top: 9px; }
-.honesty-label { font-size: .72rem; color: var(--text-faint); letter-spacing: .05em; text-transform: uppercase; }
-.honesty-bar { height: 5px; margin-top: 3px; border-radius: 3px; background: var(--surface-2); overflow: hidden; }
-.honesty-fill { height: 100%; border-radius: 3px; }
-.honesty-fill.good { background: var(--good); }
-.honesty-fill.mid { background: var(--mid); }
-.honesty-fill.bad { background: var(--bad); }
-.honesty-value { font-size: .78rem; font-variant-numeric: tabular-nums; color: var(--text-dim); }
 
 .disclose {
   width: 100%;
@@ -360,7 +352,6 @@ table.fees tr.base-row td { background: var(--surface); }
 @media (max-width: 620px) {
   .trip-main { grid-template-columns: 1fr; }
   .price-block { text-align: left; min-width: 0; }
-  .honesty-bar { max-width: 200px; }
 }
 
 .summary-caveat { color: var(--warn); }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -123,10 +123,10 @@ class TestPayload(unittest.TestCase):
             codes = [line["code"] for line in departure["lines"]]
             self.assertEqual(codes[0], "base_fare")
 
-    def test_transparency_is_a_fraction(self):
+    def test_the_page_grades_no_operators(self):
+        """The site compares what trips cost; it does not score who sells them."""
         for departure in self.payload["departures"]:
-            self.assertGreaterEqual(departure["transparency"], 0.0)
-            self.assertLessEqual(departure["transparency"], 1.0)
+            self.assertNotIn("transparency", departure)
 
 
 class TestRender(unittest.TestCase):

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -13,13 +13,7 @@ from decimal import Decimal
 from liveaboard.models import Departure, FeeItem, Itinerary, Provenance
 from liveaboard.money import FxTable, Money
 from liveaboard.dataset import Dataset
-from liveaboard.pricing import (
-    REFERENCE_BASKET,
-    compute,
-    mandatory_known,
-    resolve_fees,
-    transparency_score,
-)
+from liveaboard.pricing import compute, mandatory_known, resolve_fees
 from liveaboard.render import build_payload
 from liveaboard.taxonomy import FeeBasis, FeeCode, FeeTier, SourceKind
 
@@ -104,7 +98,7 @@ class TestTotals(unittest.TestCase):
         itinerary = make_itinerary(
             [fee(FeeCode.SINGLE_SUPPLEMENT, FeeTier.OPTIONAL, "400 EUR")]
         )
-        result = compute(itinerary, make_departure(), FX, REFERENCE_BASKET)
+        result = compute(itinerary, make_departure(), FX, {"nitrox": True, "gear": True})
         self.assertEqual(result.total.amount, Decimal("1000"))
 
     def test_conditional_fee_follows_its_toggle(self):
@@ -173,35 +167,16 @@ class TestFeeResolution(unittest.TestCase):
         )
 
 
-class TestTransparencyScore(unittest.TestCase):
-    def test_all_inclusive_scores_perfectly(self):
-        itinerary = make_itinerary(
-            [
-                fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "0 EUR", included=True),
-                fee(FeeCode.NITROX, FeeTier.CONDITIONAL, "0 EUR", included=True),
-            ]
-        )
-        self.assertEqual(transparency_score(itinerary, make_departure(), FX), 1.0)
+class TestBundlingIsVisibleWithoutAScore(unittest.TestCase):
+    """Two boats can cost the same and price very differently.
 
-    def test_hidden_fees_lower_the_score(self):
-        itinerary = make_itinerary([fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "250 EUR")])
-        self.assertAlmostEqual(transparency_score(itinerary, make_departure(), FX), 0.8)
+    The site used to express that as an honesty percentage per operator, which
+    made the page a league table and contradicted the total beside it. The
+    difference still has to be visible -- it is the whole point -- but as lines
+    in the breakdown rather than as a grade.
+    """
 
-    def test_score_ignores_visitor_toggles(self):
-        """The score describes the operator, so it must not move with the UI."""
-        itinerary = make_itinerary(
-            [
-                fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "100 EUR"),
-                fee(FeeCode.NITROX, FeeTier.CONDITIONAL, "150 EUR"),
-            ]
-        )
-        departure = make_departure()
-        first = transparency_score(itinerary, departure, FX)
-        compute(itinerary, departure, FX, {"nitrox": False})
-        self.assertEqual(first, transparency_score(itinerary, departure, FX))
-
-    def test_bundling_beats_itemising_at_equal_true_cost(self):
-        """Two boats costing the same in the end must not score the same."""
+    def test_equal_true_cost_still_reads_differently(self):
         hidden = make_itinerary([fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "200 EUR")])
         bundled = make_itinerary(
             [fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "0 EUR", included=True)]
@@ -213,10 +188,22 @@ class TestTransparencyScore(unittest.TestCase):
             compute(hidden, cheap, FX).total.amount,
             compute(bundled, dear, FX).total.amount,
         )
-        self.assertGreater(
-            transparency_score(bundled, dear, FX),
-            transparency_score(hidden, cheap, FX),
+        # The advertised prices are what differ, and that is what a visitor
+        # comparing the two actually needs to see.
+        self.assertLess(
+            compute(hidden, cheap, FX).base.amount,
+            compute(bundled, dear, FX).base.amount,
         )
+
+    def test_a_bundled_fee_keeps_its_line_at_zero(self):
+        """Deleting it would erase the difference between the two boats."""
+        bundled = make_itinerary(
+            [fee(FeeCode.MARINE_PARK, FeeTier.MANDATORY, "0 EUR", included=True)]
+        )
+        result = compute(bundled, make_departure("1200 EUR"), FX)
+        park = [line for line in result.lines if line.code is FeeCode.MARINE_PARK]
+        self.assertEqual(len(park), 1)
+        self.assertTrue(park[0].included)
 
 
 class TestOnlyOptionalExtrasIsNotACleanBill(unittest.TestCase):
@@ -279,36 +266,26 @@ class TestOnlyOptionalExtrasIsNotACleanBill(unittest.TestCase):
         ])
         self.assertTrue(mandatory_known(itinerary, departure))
 
-    def test_the_page_withholds_the_score_rather_than_awarding_it(self):
+    def test_the_page_is_told_the_required_picture_is_missing(self):
         payload = build_payload(self.dataset([
             self.fee("gratuities", "customary"),
             self.fee("course", "optional", 250.0),
         ]))
-        rendered = payload["departures"][0]
-        self.assertFalse(rendered["mandatory_known"])
-        self.assertIsNone(rendered["transparency"])
+        self.assertFalse(payload["departures"][0]["mandatory_known"])
 
-    def test_a_disclosing_operator_still_gets_scored(self):
+    def test_a_disclosing_operator_gets_a_total(self):
         payload = build_payload(self.dataset([
             self.fee("marine_park", "mandatory", 150.0),
             self.fee("gratuities", "customary"),
         ]))
-        rendered = payload["departures"][0]
-        self.assertTrue(rendered["mandatory_known"])
-        self.assertIsNotNone(rendered["transparency"])
+        self.assertTrue(payload["departures"][0]["mandatory_known"])
 
-    def test_silence_no_longer_outranks_disclosure(self):
-        """The regression in one line: quiet operator vs forthcoming one."""
-        quiet = build_payload(self.dataset([
-            self.fee("gratuities", "customary"),
-        ]))["departures"][0]
-        forthcoming = build_payload(self.dataset([
+    def test_the_page_carries_no_score_to_rank_operators_by(self):
+        """Comparing trips is the job; grading operators is not."""
+        payload = build_payload(self.dataset([
             self.fee("marine_park", "mandatory", 150.0),
-            self.fee("port_fees", "mandatory", 80.0),
-            self.fee("gratuities", "customary"),
-        ]))["departures"][0]
-        self.assertIsNone(quiet["transparency"])
-        self.assertIsNotNone(forthcoming["transparency"])
+        ]))
+        self.assertNotIn("transparency", payload["departures"][0])
 
 
 if __name__ == "__main__":

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -122,9 +122,9 @@ class TestFeesAreUnknownNotZero(unittest.TestCase):
     def test_the_page_is_told_the_fees_are_unknown(self):
         self.assertFalse(self.rendered["fees_known"])
 
-    def test_no_honesty_score_is_invented(self):
-        """A perfect score here would reward the operator for our missing work."""
-        self.assertIsNone(self.rendered["transparency"])
+    def test_no_true_cost_is_claimed(self):
+        """Nobody has looked, so the advertised price is all we can show."""
+        self.assertFalse(self.rendered["mandatory_known"])
 
 
 class TestClassificationSurvivesTheMissingSiteList(unittest.TestCase):


### PR DESCRIPTION
The honesty score turned the page into a league table, which is not what this site is for.

Worse, it disagreed with the number next to it. The score was measured against a fixed `REFERENCE_BASKET` while the total followed the visitor's own toggles — so two figures about the same trip contradicted each other, and only one of them answered the question a diver is actually asking.

## What goes

The score, its bar, its colour coding, `REFERENCE_BASKET`, `transparency_score()`, the `transparency` field in the payload, and the "Most honest pricing" sort.

## What replaces it

The money. The gap between advertised and what you pay, in euro and as a percentage:

```
  itinerary                                advertised  true cost  lands later
  Daedalus & Elphinstone (Port Ghalib)            865      1,145    280 (32%)
  Mini Safari: Best of Hurghada                   466        591    125 (27%)
  Marine Park North: Brothers - Daedalus        1,104      1,352    248 (22%)
```

Sorting is now: departure date · true cost · cost per night · advertised price · biggest gap as a percentage · **most money landing after the headline price**. Trips whose required extras are unstated sort last there rather than first — no gap to report is not the same as nothing to add.

## What must not be lost

The difference between an operator that bundles its park fees and one that bills at the dock. That was the score's job; it is now the breakdown's. An included fee keeps its line at zero, and two boats reaching the same true cost differ visibly in their advertised prices. Both pinned by tests.

The rule that an unstated required block is not a clean bill survives unchanged — it now gates the total rather than a score, which is where it always belonged.

`CLAUDE.md`'s invariant is updated to match: no score grading operators, and never claim a total the disclosure doesn't support.

195 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_