### PR TITLE
Archive what each page published, not only what we read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,4 +46,8 @@ blocked by the environment's network policy (see README), so the adapters in
 `src/liveaboard/scrape/` are structural. **Do not write markup parsers for
 pages nobody has fetched** — run a scrape, read the snapshot, then parse.
 
-`data/snapshots/` is gitignored; CI keeps it as a build artifact.
+`data/snapshots/` is gitignored; CI keeps it as a build artifact for 14 days.
+`data/archive.json` is committed and holds every JSON-LD node each page
+published, parsed or not — re-scraping recovers today's prices, never
+yesterday's. Add fields to the parser freely; do not trim the archive to match
+what the parser happens to read.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,24 @@ src/liveaboard/   taxonomy, money, models, pricing, classify, dataset, render, c
 templates/        index.html + style.css + app.js, inlined at build time
 tools/make_seed.py
 data/seed/        the seed dataset
-tests/            60 tests, stdlib unittest
+tests/            stdlib unittest, no dependencies
 ```
+
+### What is kept
+
+| file | holds | committed |
+|---|---|---|
+| `data/egypt-2027.json` | the published dataset | yes |
+| `data/candidate.json` | the raw scrape, before promotion | yes |
+| `data/fees.json` | fee book **and** the disclosure text each parse was made from | yes |
+| `data/archive.json` | every JSON-LD node each page published, parsed or not | yes |
+| `data/snapshots/` | raw pages | no — gitignored, CI artifact for 14 days |
+
+`archive.json` exists because current prices can always be re-scraped and past
+ones cannot. It carries ratings, cabin counts, occupancy, amenities and
+remaining capacity — none of which the site uses today — so a question asked
+next month can still be put to this month's data. Every run is a commit, so
+`git log -p data/` is the history.
 
 ## Next
 

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -172,6 +172,37 @@ def cmd_scrape(args: argparse.Namespace) -> int:
         encoding="utf-8",
     )
     print(f"wrote candidate {out}")
+
+    # Written beside the candidate rather than inside it: promote reads the
+    # candidate on every run and has no use for this, while this exists purely
+    # so a later question can be asked of today's data.
+    if combined.archive:
+        archive = Path(args.archive)
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        archive.write_text(
+            json.dumps(
+                {
+                    "scraped_at": date.today().isoformat(),
+                    "source": "liveaboard.com",
+                    "note": (
+                        "Structured data exactly as the source published it, "
+                        "including fields nothing parses yet. Kept because "
+                        "current prices can be re-scraped and past ones cannot."
+                    ),
+                    "pages": combined.archive,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        nodes = sum(len(page["nodes"]) for page in combined.archive)
+        print(
+            f"archived {len(combined.archive)} pages, {nodes} nodes "
+            f"-> {archive} ({archive.stat().st_size / 1024:.0f} KB)"
+        )
+
     return 1 if blocked else 0
 
 
@@ -257,6 +288,7 @@ def main(argv: list[str] | None = None) -> int:
     scrape.add_argument("--source", choices=sorted(ADAPTERS), default=None)
     scrape.add_argument("--out", default=Path("data/candidate.json"), type=Path)
     scrape.add_argument("--snapshots", default=DEFAULT_SNAPSHOTS, type=Path)
+    scrape.add_argument("--archive", default=Path("data/archive.json"), type=Path)
     scrape.add_argument(
         "--warnings", type=int, default=10, help="how many warnings to print"
     )

--- a/src/liveaboard/scrape/base.py
+++ b/src/liveaboard/scrape/base.py
@@ -194,6 +194,23 @@ class ScrapeOutput:
     itineraries: list[dict[str, Any]] = field(default_factory=list)
     departures: list[dict[str, Any]] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    archive: list[dict[str, Any]] = field(default_factory=list)
+    """The structured data each page published, whether or not we parse it.
+
+    Everything else in this class is what the adapter chose to read today. This
+    is what the page actually said, kept so a question nobody has asked yet can
+    still be answered later.
+
+    That matters because the two are not equally recoverable. Current prices can
+    always be re-scraped; the prices as they stood on a given day cannot. A
+    field we start caring about next month would otherwise arrive attached to
+    next month's data, with today's gone for good.
+
+    Snapshots do not cover this: they are gitignored and expire from CI after
+    fourteen days. This is committed, and it is JSON rather than HTML, so it
+    stays queryable without a browser -- which is precisely how the stored fee
+    disclosures turned a live re-run into an offline audit.
+    """
 
     def extend(self, other: ScrapeOutput) -> None:
         self.operators.extend(other.operators)
@@ -201,6 +218,7 @@ class ScrapeOutput:
         self.itineraries.extend(other.itineraries)
         self.departures.extend(other.departures)
         self.warnings.extend(other.warnings)
+        self.archive.extend(other.archive)
 
     @property
     def is_empty(self) -> bool:

--- a/src/liveaboard/scrape/liveaboard_com.py
+++ b/src/liveaboard/scrape/liveaboard_com.py
@@ -215,6 +215,20 @@ class LiveaboardComAdapter(SourceAdapter):
                 f"inspect the snapshot ({result.digest}) and add a markup parser"
             )
 
+        # Keep what the page published before reading anything out of it. The
+        # nodes below carry cabin types, vessel specifications, ratings and
+        # review counts that nothing here parses today; storing them costs a few
+        # hundred kilobytes a run and is the only way a later question about
+        # today's prices can still be answered.
+        output.archive.append(
+            {
+                "url": result.url,
+                "retrieved": result.fetched_at.date().isoformat(),
+                "digest": result.digest,
+                "nodes": products + events,
+            }
+        )
+
         if products:
             product = products[0]
             # Fees are a property of the vessel, not the sailing: the same

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -181,5 +181,71 @@ class TestSeasonMonthSelector(unittest.TestCase):
         self.assertTrue(output.is_empty)
 
 
+class TestArchive(unittest.TestCase):
+    """Keep what the page published, not only what we chose to read.
+
+    Current prices can always be re-scraped; the prices as they stood on a
+    given day cannot. A field that starts mattering next month would otherwise
+    arrive attached to next month's data, with today's gone.
+    """
+
+    HTML = """
+    <html><head>
+    <script type="application/ld+json">
+    {"@type":"Product","name":"MY Example","description":"A vessel.",
+     "aggregateRating":{"@type":"AggregateRating","ratingValue":"9.1","reviewCount":"214"},
+     "numberOfRooms":10,"occupancy":20,"amenityFeature":["Nitrox","Jacuzzi"],
+     "offers":{"@type":"AggregateOffer","lowPrice":"900","priceCurrency":"USD"}}
+    </script>
+    <script type="application/ld+json">
+    {"@type":"Event","name":"Brothers","startDate":"2027-05-01","endDate":"2027-05-08",
+     "remainingAttendeeCapacity":3,
+     "offers":{"@type":"Offer","price":"1450","priceCurrency":"USD"}}
+    </script>
+    </head><body></body></html>
+    """
+
+    def setUp(self):
+        adapter = LiveaboardComAdapter(PoliteFetcher(snapshot_dir="/tmp/unused"))
+        self.output = adapter.parse(result(self.HTML))
+        self.page = self.output.archive[0]
+
+    def test_the_page_is_archived_once(self):
+        self.assertEqual(len(self.output.archive), 1)
+
+    def test_it_records_where_and_when(self):
+        self.assertEqual(self.page["url"], result(self.HTML).url)
+        self.assertEqual(self.page["retrieved"], "2026-08-27")
+        self.assertTrue(self.page["digest"])
+
+    def test_fields_nothing_parses_today_are_kept(self):
+        product = self.page["nodes"][0]
+        self.assertEqual(product["numberOfRooms"], 10)
+        self.assertEqual(product["occupancy"], 20)
+        self.assertEqual(product["aggregateRating"]["reviewCount"], "214")
+        self.assertEqual(product["amenityFeature"], ["Nitrox", "Jacuzzi"])
+
+    def test_remaining_capacity_survives(self):
+        """Availability on a given day is the one thing a re-scrape cannot recover."""
+        event = self.page["nodes"][1]
+        self.assertEqual(event["remainingAttendeeCapacity"], 3)
+
+    def test_a_listing_page_archives_nothing(self):
+        adapter = LiveaboardComAdapter(PoliteFetcher(snapshot_dir="/tmp/unused"))
+        output = adapter.parse(
+            result("<html><body>nav only</body></html>",
+                   url="https://www.liveaboard.com/diving/search/egypt/may/2027")
+        )
+        self.assertEqual(output.archive, [])
+
+    def test_archives_merge_across_pages(self):
+        from liveaboard.scrape.base import ScrapeOutput
+
+        combined = ScrapeOutput()
+        combined.extend(self.output)
+        combined.extend(self.output)
+        self.assertEqual(len(combined.archive), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Re-scraping recovers today's prices. It cannot recover yesterday's.

So any field we start caring about next month arrives attached to *next month's* data, with the version that existed today gone for good. Everything the scrape keeps right now is what the adapter chose to read; the rest of each page is discarded.

## What's added

`data/archive.json` — every JSON-LD node each vessel page published, with its URL, fetch date and content digest.

Fields it preserves that nothing here parses today:

```json
"aggregateRating": {"ratingValue": "9.1", "reviewCount": "214"},
"numberOfRooms": 10,
"occupancy": 20,
"amenityFeature": ["Nitrox", "Jacuzzi"],
"remainingAttendeeCapacity": 3
```

`remainingAttendeeCapacity` is the sharpest case: **availability on a given day is exactly what a later scrape can never tell you.** Sold-out dates, how fast a boat fills, whether the cheap May departures go first — all only capturable as it happens.

Written beside the candidate rather than inside it, since `promote` reads the candidate on every run and has no use for this.

## Why snapshots don't cover it

`data/snapshots/` is gitignored and expires from CI after 14 days, and it's HTML — answering a question from it means parsing markup again. This is JSON and it's committed. That difference is exactly what turned the stored fee disclosures from a live browser re-run into an offline audit, twice today.

Cost is a few hundred KB per run, and git delta-compresses it well since most of it repeats day to day.

`CLAUDE.md` gains the rule that matters: add fields to the parser freely, but do not trim the archive to match what the parser happens to read.

201 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_