### PR TITLE
Publish the scraped dataset, not the seed

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,8 +62,16 @@ jobs:
 
       # Rebuild rather than trusting the committed file, so the published page
       # always matches the dataset in the same commit.
+      #
+      # The dataset is named explicitly. This step used to rely on the build
+      # default, which pointed at the seed, so every deploy published five
+      # placeholder boats while the repository held sixty-seven scraped ones.
+      # The default now prefers the real dataset, but a deploy should not be
+      # the thing that discovers a default changed underneath it.
       - name: Build
-        run: PYTHONPATH=src python3 -m liveaboard.cli build
+        run: |
+          PYTHONPATH=src python3 -m liveaboard.cli build \
+            --data "$([ -f data/egypt-2027.json ] && echo data/egypt-2027.json || echo data/seed/egypt-2027.json)"
 
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -22,7 +22,27 @@ from .scrape.base import FetchBlocked, PoliteFetcher, ScrapeOutput
 from .scrape.liveaboard_com import LiveaboardComAdapter
 from .scrape.padi_com import PadiComAdapter
 
-DEFAULT_DATA = Path("data/seed/egypt-2027.json")
+SEED_DATA = Path("data/seed/egypt-2027.json")
+LIVE_DATA = Path("data/egypt-2027.json")
+
+
+def default_data() -> Path:
+    """The dataset to use when nobody names one.
+
+    This was a constant pointing at the seed, and the deploy job builds with no
+    --data. So every published page was built from five placeholder boats while
+    the repository beside it held sixty-seven scraped ones, and the seed banner
+    on the live site was telling the truth about a page nobody meant to ship.
+
+    Verifying it did not catch this: rebuilding from main with an explicit
+    --data reproduces what the *commit* step builds, not what the *deploy* step
+    builds. The two only diverged because of this default.
+
+    Preferring the real dataset means the seed is what you get on a fresh
+    checkout that has never scraped, which is the only time it is the right
+    answer.
+    """
+    return LIVE_DATA if LIVE_DATA.exists() else SEED_DATA
 DEFAULT_OUT = Path("site")
 DEFAULT_SNAPSHOTS = Path("data/snapshots")
 
@@ -33,7 +53,9 @@ ADAPTERS = {
 
 
 def cmd_build(args: argparse.Namespace) -> int:
-    dataset = Dataset.load(args.data)
+    data = args.data or default_data()
+    dataset = Dataset.load(data)
+    print(f"building from {data}")
     target = render(dataset, args.out)
     payload_size = target.stat().st_size
     print(f"built {target} ({payload_size / 1024:.0f} KB)")
@@ -48,13 +70,14 @@ def cmd_build(args: argparse.Namespace) -> int:
 
 def cmd_check(args: argparse.Namespace) -> int:
     """Validate the dataset and print what the engine makes of it."""
+    data = args.data or default_data()
     try:
-        dataset = Dataset.load(args.data)
+        dataset = Dataset.load(data)
     except DatasetError as exc:
         print(f"dataset invalid: {exc}", file=sys.stderr)
         return 1
 
-    print(f"{args.data}: valid")
+    print(f"{data}: valid")
     print(f"  sources: {', '.join(sorted(k.value for k in dataset.source_kinds))}")
     print()
 
@@ -289,12 +312,12 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     build = sub.add_parser("build", help="render the static site")
-    build.add_argument("--data", default=DEFAULT_DATA, type=Path)
+    build.add_argument("--data", default=None, type=Path)
     build.add_argument("--out", default=DEFAULT_OUT, type=Path)
     build.set_defaults(func=cmd_build)
 
     check = sub.add_parser("check", help="validate the dataset and summarise it")
-    check.add_argument("--data", default=DEFAULT_DATA, type=Path)
+    check.add_argument("--data", default=None, type=Path)
     check.set_defaults(func=cmd_check)
 
     scrape = sub.add_parser("scrape", help="refresh from the source sites")

--- a/templates/app.js
+++ b/templates/app.js
@@ -15,8 +15,6 @@
      liveaboard/taxonomy.py — change one and you must change the other. */
   var DEFAULT_ON_TIERS = { base: true, mandatory: true, customary: true };
 
-  var LEVEL_ORDER = DATA.facets.levels.map(function (l) { return l.id; });
-
   var euro = new Intl.NumberFormat("en-IE", {
     style: "currency", currency: DATA.meta.currency,
     minimumFractionDigits: 0, maximumFractionDigits: 0
@@ -28,8 +26,6 @@
     toggles: {},
     months: new Set(),
     routes: new Set(),
-    levels: new Set(),
-    themes: new Set(),
     open: new Set()
   };
 
@@ -84,19 +80,6 @@
     var itin = DATA.itineraries[dep.itinerary_id];
     if (state.months.size && !state.months.has(dep.month)) return false;
     if (state.routes.size && !state.routes.has(itin.route)) return false;
-    if (state.themes.size) {
-      var hit = itin.themes.some(function (t) { return state.themes.has(t); });
-      if (!hit) return false;
-    }
-    if (state.levels.size) {
-      /* "I am qualified to X" means show everything at or below X, not only
-         trips demanding exactly X. */
-      var ceiling = -1;
-      state.levels.forEach(function (l) {
-        ceiling = Math.max(ceiling, LEVEL_ORDER.indexOf(l));
-      });
-      if (LEVEL_ORDER.indexOf(itin.level) > ceiling) return false;
-    }
     return true;
   }
 
@@ -511,8 +494,6 @@
     drawToggles();
     chipRow("months", DATA.facets.months, state.months);
     chipRow("routes", DATA.facets.routes, state.routes);
-    chipRow("levels", DATA.facets.levels, state.levels);
-    chipRow("themes", DATA.facets.themes, state.themes);
 
     var matching = DATA.departures.filter(passesFilters);
     var results = document.getElementById("results");
@@ -589,8 +570,6 @@
   document.getElementById("reset").addEventListener("click", function () {
     state.months.clear();
     state.routes.clear();
-    state.levels.clear();
-    state.themes.clear();
     DATA.facets.toggles.forEach(function (t) { state.toggles[t.id] = t.default; });
     draw();
   });

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,14 +67,6 @@
         <span class="control-label" id="routeLabel">Route</span>
         <div class="chips" id="routes" role="group" aria-labelledby="routeLabel"></div>
       </div>
-      <div class="control-group">
-        <span class="control-label" id="levelLabel">I am qualified to</span>
-        <div class="chips" id="levels" role="group" aria-labelledby="levelLabel"></div>
-      </div>
-      <div class="control-group">
-        <span class="control-label" id="themeLabel">Looking for</span>
-        <div class="chips" id="themes" role="group" aria-labelledby="themeLabel"></div>
-      </div>
     </div>
 
     <div class="control-row summary-row">

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -283,5 +283,35 @@ class TestFxHonesty(unittest.TestCase):
         self.assertIn("sourced", payload["meta"]["fx"])
 
 
+class TestDefaultDataset(unittest.TestCase):
+    """The default decided what got published, and it pointed at the seed."""
+
+    def test_the_real_dataset_wins_when_it_exists(self):
+        from liveaboard.cli import LIVE_DATA, default_data
+
+        if not LIVE_DATA.exists():
+            self.skipTest("no scraped dataset in this checkout")
+        self.assertEqual(default_data(), LIVE_DATA)
+
+    def test_the_seed_is_the_fallback_not_the_default(self):
+        """A fresh checkout that has never scraped is the only time it is right."""
+        import liveaboard.cli as cli
+
+        original = cli.LIVE_DATA
+        try:
+            cli.LIVE_DATA = Path("data/definitely-not-here.json")
+            self.assertEqual(cli.default_data(), cli.SEED_DATA)
+        finally:
+            cli.LIVE_DATA = original
+
+    def test_the_deploy_names_its_dataset(self):
+        """Relying on the default published five placeholder boats for hours."""
+        workflow = (
+            Path(__file__).resolve().parents[1] / ".github/workflows/pages.yml"
+        ).read_text(encoding="utf-8")
+        build = workflow.split("- name: Build", 1)[1]
+        self.assertIn("--data", build.split("- uses:", 1)[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**The live site has been serving the seed dataset.**

`pages.yml` builds with no `--data`, and the build default was `data/seed/egypt-2027.json`:

```
$ cli build                                  # what the deploy runs
  58 departures, 6 itineraries, 5 boats
  note: dataset contains seed estimates; the page says so prominently

$ cli build --data data/egypt-2027.json      # what the commit step runs
  860 departures, 313 itineraries, 67 boats
```

Five placeholder boats published, sixty-seven scraped ones sitting in the repository beside them. The seed banner on the live page was telling the truth about a page nobody meant to ship — as was the "approximate rate" banner, since the seed carries the placeholder FX.

## Why verifying it didn't catch this

Worth writing down, because I checked the deploy more than once and it looked right. Rebuilding from `main` with an explicit `--data` reproduces what the **commit** step builds, not what the **deploy** step builds. The two only ever differed because of this default — so inspecting the committed HTML looked exactly like inspecting the published one.

## The fix, deliberately overlapping

- `default_data()` prefers `data/egypt-2027.json`, falling back to the seed only on a checkout that has never scraped — the one time the seed is the right answer.
- The deploy **names its dataset outright**. A deploy should not be the thing that discovers a default moved underneath it.
- Both `build` and `check` now print which file they read.

A test asserts the Build step passes `--data`, so this cannot silently revert.

## Also

Removes the **"I am qualified to"** and **"Looking for"** filters, as requested. The level and theme badges stay on the cards — what goes is the filtering, not the classification behind it.

227 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_