### PR TITLE
Fold duplicate port names and pin the footer to the bottom edge

### DIFF
--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -66,6 +66,36 @@ reading off the only place the source puts it.
 """
 
 
+PORT_ALIASES: dict[str, str] = {
+    # Port Ghalib's marina is written three ways across the fleet. "Marsa" is
+    # Arabic for the harbour itself, and Ras Galep is the headland it sits on.
+    "marsa ghalib": "Port Ghalib",
+    "ras galep | port ghalib": "Port Ghalib",
+    # A hotel pickup point, not a port.
+    "hurghada, marriott": "Hurghada",
+    # Soma Bay is a resort bay ten kilometres up the coast from Safaga, and the
+    # operator names both because it uses whichever berth it is given.
+    "safaga/soma bay": "Safaga",
+}
+"""Ports that are one place under several spellings.
+
+Left unmerged they made ten filter chips out of six real harbours, and split
+the departures leaving from one marina across three of them -- which is worse
+than cosmetic on a filter whose whole job is "which airport do I fly into".
+
+Deliberately narrow. Marsa Alam is sixty kilometres south of Port Ghalib and
+stays its own port, however similar the names look.
+"""
+
+
+def _port(name: str | None) -> str:
+    """Fold an operator's spelling of a harbour onto one name."""
+    if not name:
+        return "Unknown"
+    cleaned = " ".join(name.split())
+    return PORT_ALIASES.get(cleaned.lower(), cleaned)
+
+
 def _split_title(name: str) -> tuple[str, str | None, tuple[str, str] | None]:
     """Split a scraped trip title into route, promotion and ports."""
     promotion = None
@@ -206,6 +236,7 @@ def promote(
         port_from, port_to = titled_ports or (
             (located[0], located[0]) if located else ("Unknown", "Unknown")
         )
+        port_from, port_to = _port(port_from), _port(port_to)
 
         itineraries.append(
             {

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,8 +76,11 @@
   </table>
 </main>
 
-<footer class="site-footer">
-  <h2>How the numbers are built</h2>
+<details class="site-footer">
+  <summary>
+    How the numbers are built
+    <span class="colophon">Generated __GENERATED__.</span>
+  </summary>
   <div class="footer-grid">
     <div>
       <h3>True cost</h3>
@@ -131,8 +134,7 @@
       </p>
     </div>
   </div>
-  <p class="colophon">Generated __GENERATED__.</p>
-</footer>
+</details>
 
 <script id="payload" type="application/json">"__DATA__"</script>
 <script>/*APP*/</script>

--- a/templates/style.css
+++ b/templates/style.css
@@ -36,11 +36,18 @@
 
 * { box-sizing: border-box; }
 
+/* An app shell, not a document: the window never scrolls, the table scrolls
+   inside it, and the footer sits on the bottom edge where it can always be
+   reached without hunting for it. */
+html, body { height:100%; }
+
 body {
   margin:0; background:var(--ground); color:var(--ink);
   font-family:"IBM Plex Sans","Helvetica Neue",Arial,sans-serif;
   font-size:13px; line-height:1.45; -webkit-font-smoothing:antialiased;
+  display:flex; flex-direction:column; overflow:hidden;
 }
+body > * { flex:none; }
 
 h1 {
   font-family:"IBM Plex Sans Condensed","IBM Plex Sans",sans-serif;
@@ -110,8 +117,10 @@ input[type="search"] {
   min-width:200px;
 }
 
-/* The table's own scroll container: the body must never scroll sideways. */
-.shell { overflow:auto; max-height:calc(100vh - 240px); background:var(--panel); }
+/* The only scrolling region on the page. min-height:0 is load-bearing: without
+   it a flex child refuses to shrink below its content and pushes the footer
+   off the bottom, which is the bug this layout exists to prevent. */
+.shell { flex:1 1 auto; min-height:0; overflow:auto; background:var(--panel); }
 table { border-collapse:separate; border-spacing:0; width:max-content; min-width:100%; }
 
 thead th {
@@ -181,22 +190,31 @@ tr.detail td { background:var(--ground); padding:12px 18px; white-space:normal; 
 
 .empty { padding:26px 18px; color:var(--ink-dim); }
 
+/* Collapsed it is one line on the bottom edge; opened it takes only as much
+   of the table's room as it needs, and gives it straight back. */
 .site-footer {
-  padding:22px 18px 30px; border-top:1px solid var(--rule);
-  background:var(--panel); color:var(--ink-dim);
+  border-top:1px solid var(--rule); background:var(--panel); color:var(--ink-dim);
+  max-height:52vh; overflow:auto;
 }
-.site-footer h2 {
+.site-footer > summary {
+  padding:9px 18px; cursor:pointer; list-style:none;
   font-family:"IBM Plex Sans Condensed","IBM Plex Sans",sans-serif;
-  font-size:13px; text-transform:uppercase; letter-spacing:.09em;
-  color:var(--ink-faint); margin:0 0 12px; font-weight:600;
+  font-size:11px; text-transform:uppercase; letter-spacing:.09em;
+  color:var(--ink-faint); font-weight:600;
+  display:flex; gap:14px; align-items:baseline;
 }
+.site-footer > summary::-webkit-details-marker { display:none; }
+.site-footer > summary::before { content:"▸"; color:var(--accent); }
+.site-footer[open] > summary::before { content:"▾"; }
+.site-footer > summary:hover { color:var(--accent); }
+.site-footer .footer-grid { padding:4px 18px 20px; }
 .footer-grid {
   display:grid; gap:16px 28px;
   grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
 }
 .site-footer h3 { font-size:12px; margin:0 0 3px; color:var(--ink); font-weight:600; }
 .site-footer p { margin:0; font-size:11.5px; max-width:60ch; }
-.colophon { margin-top:18px; font-size:11px; color:var(--ink-faint); }
+.colophon { margin-left:auto; text-transform:none; letter-spacing:0; font-weight:400; }
 
 a { color:var(--accent); }
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -268,7 +268,11 @@ class TestPortsFromTitle(unittest.TestCase):
             "(Port Ghalib - Safaga/Soma Bay)"
         )
         self.assertEqual(itinerary["port_from"], "Port Ghalib")
-        self.assertEqual(itinerary["port_to"], "Safaga/Soma Bay")
+        # Folded onto Safaga: Soma Bay is a resort bay ten kilometres up the
+        # coast and the operator names both because it takes whichever berth
+        # it is given. Still two different ports, which is the point here.
+        self.assertEqual(itinerary["port_to"], "Safaga")
+        self.assertNotEqual(itinerary["port_from"], itinerary["port_to"])
 
     def test_the_title_beats_the_country_the_source_reports(self):
         itinerary = self.promote_one("North (Hurghada - Hurghada)")
@@ -441,6 +445,36 @@ class TestGuestCount(unittest.TestCase):
         )
         self.assertEqual(payload["boats"][0]["guests"], 20)
         self.assertNotIn("guests", payload["itineraries"][0])
+
+
+class TestPortNames(unittest.TestCase):
+    """One harbour under several spellings made ten chips out of six ports."""
+
+    def port(self, name):
+        from liveaboard.promote import _port
+
+        return _port(name)
+
+    def test_the_ghalib_marina_is_one_place(self):
+        for spelling in ("Port Ghalib", "Marsa Ghalib", "Ras Galep | Port Ghalib"):
+            self.assertEqual(self.port(spelling), "Port Ghalib", spelling)
+
+    def test_a_hotel_pickup_is_not_a_port(self):
+        self.assertEqual(self.port("Hurghada, Marriott"), "Hurghada")
+
+    def test_marsa_alam_is_not_port_ghalib(self):
+        """Sixty kilometres apart, however similar the names look."""
+        self.assertEqual(self.port("Marsa Alam"), "Marsa Alam")
+
+    def test_an_unknown_port_keeps_its_own_name(self):
+        self.assertEqual(self.port("Berenice"), "Berenice")
+
+    def test_whitespace_does_not_defeat_the_match(self):
+        self.assertEqual(self.port("  Marsa   Ghalib "), "Port Ghalib")
+
+    def test_a_missing_port_is_unknown_not_blank(self):
+        self.assertEqual(self.port(None), "Unknown")
+        self.assertEqual(self.port(""), "Unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Ports

Ten filter chips covered six real harbours:

| was | now |
| --- | --- |
| `Port Ghalib` 140 · `Marsa Ghalib` 40 · `Ras Galep \| Port Ghalib` 4 | **Port Ghalib** 188 |
| `Hurghada` 457 · `Hurghada, Marriott` 8 | **Hurghada** 471 |
| `Safaga` 29 · `Safaga/Soma Bay` 1 | **Safaga** 30 |

Departures leaving from one marina were split across three chips — worse than cosmetic on a filter whose whole job is *which airport do I fly into*. "Marsa" is Arabic for the harbour itself and Ras Galep is the headland it sits on; the Marriott is a hotel pickup, not a port; Soma Bay is a resort bay ten kilometres up the coast that one operator names alongside Safaga because it takes whichever berth it is given.

The map is **deliberately narrow**. Marsa Alam is sixty kilometres south of Port Ghalib and stays its own port, however similar the names look.

Final: Hurghada 471 · Port Ghalib 188 · Sharm El Sheikh 101 · Marsa Alam 69 · Safaga 30 · Hamata 27.

## Layout

The page is now an **app shell rather than a document**: the window does not scroll, the table scrolls inside it, and "How the numbers are built" sits on the bottom edge where it can be reached without hunting for it.

It is a `<details>`, so collapsed it is one line — heading plus build date — and opened it borrows only as much of the table's room as it needs (capped at 52vh, scrolling internally beyond that).

`min-height: 0` on the scrolling region is load-bearing: without it a flex child refuses to shrink below its content and pushes the footer off the bottom, which is precisely the bug this layout exists to prevent.

238 tests pass. One existing test needed updating rather than fixing — it asserted `port_to == "Safaga/Soma Bay"`, which is now `"Safaga"`; it still checks the ports differ, since that one-way case is what the test is actually about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_