### PR TITLE
Add price per dive, with the assumption on the face of it

### DIFF
--- a/src/liveaboard/models.py
+++ b/src/liveaboard/models.py
@@ -253,6 +253,14 @@ class Itinerary:
     fees: list[FeeItem] = field(default_factory=list)
     source_url: str | None = None
     summary: str | None = None
+    dives_estimated: bool = False
+    """Whether ``dives`` was counted from the listing or worked out from nights.
+
+    The source publishes no per-trip dive count, so for now this is true
+    everywhere a count exists at all. It has to reach the page: price per dive
+    computed from an assumed denominator is a weaker claim than one computed
+    from a stated count, and the two must not look alike.
+    """
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any], default_currency: str) -> Itinerary:
@@ -273,6 +281,7 @@ class Itinerary:
             fees=[FeeItem.from_dict(f, default_currency) for f in payload.get("fees", [])],
             source_url=payload.get("source_url"),
             summary=payload.get("summary"),
+            dives_estimated=bool(payload.get("dives_estimated", False)),
         )
 
 

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -155,6 +155,39 @@ def _guests(summary: str | None) -> int | None:
     return None
 
 
+DIVES_PER_FULL_DAY = 3
+"""Dives on a day spent at sea, which is the industry's own standard shape.
+
+Egyptian liveaboards run a three-dive day plus night dives on request. This is
+the number every operator's schedule is built around, and the one divers assume
+when they compare a week against a mini-safari.
+"""
+
+
+def _dives(nights: int, stated: int | None = None) -> int:
+    """How many dives a trip of this length runs.
+
+    An operator's own figure wins whenever there is one. There is not: the
+    source publishes no per-trip count, and what does appear on a vessel page
+    is a marketing maximum -- "up to 18 dives per week" -- attached to the boat
+    rather than the sailing.
+
+    So this is worked out from nights, and the arithmetic is deliberately
+    conservative. Full diving days are ``nights - 1``: the first day is arrival
+    and a check dive, the last is a dry day before flying. Three dives on each
+    of those gives eighteen for a seven-night week, which is exactly the figure
+    the two vessels stating one both publish.
+
+    Erring low matters in one direction only. Assuming *more* dives divides the
+    bill by a bigger number and makes every trip look cheaper per dive, which
+    is the failure this site exists to correct. A trip that turns out to run
+    more dives than this is a better deal than the page claims, never worse.
+    """
+    if stated and stated > 0:
+        return stated
+    return max(1, (nights - 1) * DIVES_PER_FULL_DAY)
+
+
 def _nights(start: str, end: str) -> int | None:
     try:
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
@@ -245,7 +278,8 @@ def promote(
                 "operator_id": UNKNOWN_OPERATOR["id"],
                 "boat_id": slug,
                 "nights": nights,
-                "dives": 0,
+                "dives": _dives(nights, source.get("dives")),
+                "dives_estimated": not source.get("dives"),
                 "port_from": port_from,
                 "port_to": port_to,
                 # Left empty on purpose. Route and theme are derived from dive

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -68,6 +68,7 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
             "operator": operator.name,
             "nights": itinerary.nights,
             "dives": itinerary.dives,
+            "dives_estimated": itinerary.dives_estimated,
             "port_from": itinerary.port_from,
             "port_to": itinerary.port_to,
             "one_way": itinerary.port_from != itinerary.port_to,

--- a/templates/app.js
+++ b/templates/app.js
@@ -152,6 +152,22 @@
       show: function (d, i, m) {
         return d.mandatory_known ? "<b>" + span(m) + "</b>" : '<span class="dim">—</span>';
       } },
+    /* Price per dive is what divers compare on, so it earns a column even
+       though the denominator is worked out rather than published. Marked with
+       a tilde wherever it is: a figure divided by an assumption is a weaker
+       claim than one divided by a stated count, and the two must not look
+       alike on the same page. */
+    { k: "perdive", t: "Per dive", num: true,
+      v: function (d, i, m) { return i.dives > 0 ? m.total / i.dives : -1; },
+      show: function (d, i, m) {
+        if (!d.mandatory_known || !i.dives) return '<span class="dim">—</span>';
+        var value = eur(m.total / i.dives);
+        return i.dives_estimated
+          ? '<span class="est" title="' + i.dives +
+            ' dives assumed: three a day for every full day at sea. The ' +
+            'operator does not publish a count.">~' + value + "</span>"
+          : value;
+      } },
     { k: "later", t: "Lands later", num: true,
       v: function (d, i, m) { return m.later; },
       show: function (d, i, m) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,6 +109,16 @@
       </p>
     </div>
     <div>
+      <h3>Per dive</h3>
+      <p>
+        Marked <span class="est">~</span> because the denominator is worked
+        out, not published: three dives for every full day at sea, so eighteen
+        on a seven-night week &mdash; the figure the two vessels that state one
+        both give. Erring low on purpose. Assuming more dives would divide the
+        bill by a bigger number and make every trip look cheaper than it is.
+      </p>
+    </div>
+    <div>
       <h3>Disclosure</h3>
       <p>
         Whether the operator published its required extras at all. A listing

--- a/templates/style.css
+++ b/templates/style.css
@@ -157,6 +157,9 @@ tbody tr.row:hover .stick { background:var(--row-hover); }
 thead th.stick { z-index:25; }
 
 .later { color:var(--later); font-weight:600; }
+/* A number divided by an assumption. Dotted underline rather than a colour:
+   it is a weaker claim, not a warning. */
+.est { border-bottom:1px dotted var(--ink-faint); cursor:help; }
 .dim { color:var(--ink-faint); }
 .trip { white-space:normal; min-width:210px; max-width:320px; }
 .sites { white-space:normal; min-width:150px; max-width:210px; color:var(--ink-dim); font-size:11px; }

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -477,5 +477,59 @@ class TestPortNames(unittest.TestCase):
         self.assertEqual(self.port(""), "Unknown")
 
 
+class TestDiveCount(unittest.TestCase):
+    """Price per dive is what divers compare on; the count is not published."""
+
+    def dives(self, nights, stated=None):
+        from liveaboard.promote import _dives
+
+        return _dives(nights, stated)
+
+    def test_a_week_matches_the_only_figure_operators_publish(self):
+        """Two vessels state "up to 18 dives per week". Nothing states more."""
+        self.assertEqual(self.dives(7), 18)
+
+    def test_the_first_and_last_days_are_not_diving_days(self):
+        """Arrival plus a check dive, then a dry day before flying."""
+        self.assertEqual(self.dives(4), 9)
+        self.assertEqual(self.dives(14), 39)
+
+    def test_an_operator_count_wins_outright(self):
+        self.assertEqual(self.dives(7, 22), 22)
+
+    def test_it_errs_low_rather_than_high(self):
+        """Assuming more dives divides the bill by a bigger number and makes
+        every trip look cheaper per dive than it is."""
+        self.assertLess(self.dives(7), 7 * 3)
+
+    def test_the_shortest_trip_still_dives(self):
+        self.assertGreaterEqual(self.dives(1), 1)
+
+    def test_the_page_is_told_the_count_was_assumed(self):
+        payload = promote(candidate([departure()]), season=SEASON)
+        itinerary = payload["itineraries"][0]
+        self.assertEqual(itinerary["dives"], 18)
+        self.assertTrue(itinerary["dives_estimated"])
+
+    def test_a_scraped_count_is_not_flagged_as_assumed(self):
+        payload = promote(
+            candidate(
+                [departure()],
+                itineraries=[{"id": "alia-soul", "boat": "Alia Soul", "dives": 20}],
+            ),
+            season=SEASON,
+        )
+        self.assertEqual(payload["itineraries"][0]["dives"], 20)
+        self.assertFalse(payload["itineraries"][0]["dives_estimated"])
+
+    def test_the_flag_survives_into_the_rendered_page(self):
+        rendered = build_payload(
+            Dataset.from_dict(promote(candidate([departure()]), season=SEASON))
+        )
+        itinerary = next(iter(rendered["itineraries"].values()))
+        self.assertTrue(itinerary["dives_estimated"])
+        self.assertEqual(itinerary["dives"], 18)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Price per dive is the number divers compare on, so it earns a column even though the source publishes no per-trip dive count.

## The denominator

Three dives for every full day at sea, where full days are `nights - 1` — the first day is arrival and a check dive, the last is dry before flying.

```
 3 nights →  6 dives      7 nights → 18 dives
 4 nights →  9 dives     14 nights → 39 dives
```

A seven-night week gives **eighteen — exactly the figure both vessels that state one publish** ("up to 18 dives per week"). An operator's own count wins outright wherever one appears; none do today.

## It errs low on purpose

This matters in one direction only. Assuming *more* dives divides the bill by a bigger number and makes every trip look cheaper per dive — the failure this site exists to correct. A trip that runs more dives than this is a better deal than the page claims, never worse.

## The assumption is visible

The column marks an assumed denominator with a **tilde** and explains on hover: *"18 dives assumed: three a day for every full day at sea. The operator does not publish a count."* A figure divided by an assumption is a weaker claim than one divided by a stated count, and the two must not look alike on the same page. `dives_estimated` rides on the itinerary through to the payload, so the moment a real count is scraped the tilde disappears by itself.

## It reads as intended

```
 €54/dive  14n 39d  €2,124  Aphrodite
 €56/dive   7n 18d  €1,001  Sunshine
€145/dive   7n 18d  €2,617  Queen Sherry
€165/dive   3n  6d    €990  Serenity
```

A three-night Serenity costs three times per dive what a fortnight on Aphrodite does — the comparison per night couldn't make, and the reason you asked for it.

246 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_