### PR TITLE
Say which departures are actually bookable

### DIFF
--- a/src/liveaboard/models.py
+++ b/src/liveaboard/models.py
@@ -296,8 +296,21 @@ class Departure:
     price: Money
     price_provenance: Provenance
     spaces_left: int | None = None
+    availability: str | None = None
+    """Whether this sailing can still be booked.
+
+    ``"available"``, ``"limited"``, ``"sold_out"``, or ``None`` when the source
+    did not say. A sold-out departure priced alongside bookable ones is a
+    comparison site recommending something nobody can buy, so this has to reach
+    the page rather than being dropped on the way.
+    """
     fees: list[FeeItem] = field(default_factory=list)
     booking_url: str | None = None
+
+    @property
+    def bookable(self) -> bool:
+        """Anything but a stated sold-out. Unknown is not a refusal."""
+        return self.availability != "sold_out"
 
     @property
     def month(self) -> int:
@@ -313,6 +326,7 @@ class Departure:
             price=Money.parse(payload["price"], default_currency),
             price_provenance=Provenance.from_dict(payload["provenance"]),
             spaces_left=payload.get("spaces_left"),
+            availability=payload.get("availability"),
             fees=[FeeItem.from_dict(f, default_currency) for f in payload.get("fees", [])],
             booking_url=payload.get("booking_url"),
         )

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -188,6 +188,35 @@ def _dives(nights: int, stated: int | None = None) -> int:
     return max(1, (nights - 1) * DIVES_PER_FULL_DAY)
 
 
+AVAILABILITY = {
+    "soldout": "sold_out",
+    "outofstock": "sold_out",
+    "limitedavailability": "limited",
+    "instock": "available",
+    "onlineonly": "available",
+    "instoreonly": "available",
+    "preorder": "available",
+}
+"""schema.org availability, folded to what a diver needs to know.
+
+The scrape has carried this from the start and promote threw it away, so 127
+sold-out departures sat on the page priced exactly like the 746 bookable ones.
+On a page whose whole job is comparison that is worse than a missing column:
+sorting by cheapest could put a trip nobody can buy at the top of the list.
+
+Unknown stays unknown. A source that says nothing about availability has not
+said the trip is full.
+"""
+
+
+def _availability(raw: str | None) -> str | None:
+    """Read schema.org's availability URL, or admit the source was silent."""
+    if not raw:
+        return None
+    token = str(raw).rstrip("/").rsplit("/", 1)[-1].replace("_", "").lower()
+    return AVAILABILITY.get(token)
+
+
 def _nights(start: str, end: str) -> int | None:
     try:
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
@@ -302,6 +331,7 @@ def promote(
                 "end": item["end"],
                 "price": item["price"],
                 "booking_url": item.get("booking_url"),
+                "availability": _availability(item.get("availability")),
                 "provenance": item["provenance"],
             }
             # Carried on the departure, not the itinerary: the operator

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -108,6 +108,8 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
                 "month": departure.start.month,
                 "nights": itinerary.nights,
                 "spaces_left": departure.spaces_left,
+                "availability": departure.availability,
+                "bookable": departure.bookable,
                 "booking_url": departure.booking_url,
                 "base": float(breakdown.base.rounded),
                 "lines": [line.as_dict() for line in breakdown.lines],

--- a/templates/app.js
+++ b/templates/app.js
@@ -23,7 +23,7 @@
   var state = {
     sort: "start", dir: 1, q: "",
     months: new Set(), ports: new Set(), sites: new Set(),
-    nightsMin: null, nightsMax: null,
+    nightsMin: null, nightsMax: null, hideSoldOut: false,
     toggles: {}, open: null
   };
   D.facets.toggles.forEach(function (t) { state.toggles[t.id] = t.default; });
@@ -187,6 +187,19 @@
           ? '<span class="later">' + m.unpriced.length + "</span>"
           : '<span class="dim">0</span>';
       } },
+    /* 127 of 886 departures are sold out. Priced alongside bookable ones with
+       no way to tell them apart, a cheapest-first sort could put a trip nobody
+       can buy at the top of the list. */
+    { k: "availability", t: "Places",
+      v: function (d) {
+        return d.availability === "sold_out" ? 2 : d.availability === "limited" ? 0 : 1;
+      },
+      show: function (d) {
+        if (d.availability === "sold_out") return '<span class="pill gone">sold out</span>';
+        if (d.availability === "limited") return '<span class="pill few">few left</span>';
+        if (d.availability === "available") return '<span class="pill open">available</span>';
+        return '<span class="dim">—</span>';
+      } },
     { k: "disclosure", t: "Disclosure", v: function (d) { return disclosure(d)[1]; },
       show: function (d) {
         var s = disclosure(d);
@@ -207,6 +220,7 @@
     D.departures.forEach(function (dep) {
       var itin = D.itineraries[dep.itinerary_id];
       if (state.months.size && !state.months.has(dep.month)) return;
+      if (state.hideSoldOut && !dep.bookable) return;
       if (state.nightsMin !== null && dep.nights < state.nightsMin) return;
       if (state.nightsMax !== null && dep.nights > state.nightsMax) return;
       if (state.ports.size && !state.ports.has(itin.port_from)) return;
@@ -304,7 +318,7 @@
               (c.stick ? " stick" : "") + '">' + v + "</td>";
           }).join("");
           var open = state.open === row.d.id;
-          return '<tr class="row">' + tds + '<td><button class="expand" data-n="' + n +
+          return '<tr class="row' + (row.d.bookable ? "" : " gone") + '">' + tds + '<td><button class="expand" data-n="' + n +
             '" aria-expanded="' + open + '">' + (open ? "−" : "+") + "</button></td></tr>" +
             (open ? '<tr class="detail"><td colspan="' + (COLS.length + 1) + '">' +
               feeTable(row) + "</td></tr>" : "");
@@ -444,6 +458,13 @@
   nmin.addEventListener("input", readNights);
   nmax.addEventListener("input", readNights);
 
+  var soldOut = document.getElementById("hideSold");
+  soldOut.addEventListener("click", function () {
+    state.hideSoldOut = !state.hideSoldOut;
+    soldOut.setAttribute("aria-pressed", state.hideSoldOut);
+    draw();
+  });
+
   document.getElementById("q").addEventListener("input", function (event) {
     state.q = event.target.value.toLowerCase().trim();
     draw();
@@ -453,6 +474,8 @@
     state.months.clear(); state.ports.clear(); state.sites.clear();
     state.q = "";
     state.nightsMin = state.nightsMax = null;
+    state.hideSoldOut = false;
+    soldOut.setAttribute("aria-pressed", "false");
     document.getElementById("q").value = "";
     nmin.value = ""; nmax.value = "";
     D.facets.toggles.forEach(function (t) { state.toggles[t.id] = t.default; });

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,6 +46,9 @@
     <input id="nmax" type="number" inputmode="numeric" aria-label="Most nights">
   </div>
   <div class="tgroup">
+    <button type="button" class="chip" id="hideSold" aria-pressed="false">Hide sold out</button>
+  </div>
+  <div class="tgroup">
     <input id="q" type="search" placeholder="boat, route, port, site&hellip;" aria-label="Search">
   </div>
   <div class="tgroup meta-right">
@@ -116,6 +119,15 @@
         on a seven-night week &mdash; the figure the two vessels that state one
         both give. Erring low on purpose. Assuming more dives would divide the
         bill by a bigger number and make every trip look cheaper than it is.
+      </p>
+    </div>
+    <div>
+      <h3>Places</h3>
+      <p>
+        Straight from the operator&rsquo;s own listing: available, a few left,
+        or sold out. A hundred and twenty-seven of these departures are already
+        full, and pricing them beside bookable ones without saying so would put
+        trips nobody can buy at the top of a cheapest-first sort.
       </p>
     </div>
     <div>

--- a/templates/style.css
+++ b/templates/style.css
@@ -171,6 +171,11 @@ thead th.stick { z-index:25; }
 .pill.full { color:var(--ok); }
 .pill.partial { color:var(--warn); }
 .pill.none { color:var(--unknown); }
+.pill.open { color:var(--ok); }
+.pill.few { color:var(--warn); }
+.pill.gone { color:var(--unknown); background:var(--rule); border-color:transparent; }
+/* A sold-out row stays legible but stops competing for attention. */
+tbody tr.row.gone td:not(.stick) { opacity:.55; }
 
 .expand {
   background:none; border:0; color:var(--ink-faint); cursor:pointer;

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -531,5 +531,51 @@ class TestDiveCount(unittest.TestCase):
         self.assertEqual(itinerary["dives"], 18)
 
 
+class TestAvailability(unittest.TestCase):
+    """127 of 886 departures were sold out and the page could not say so."""
+
+    def avail(self, raw):
+        from liveaboard.promote import _availability
+
+        return _availability(raw)
+
+    def test_the_values_the_source_actually_returns(self):
+        for raw, expected in (
+            ("https://schema.org/SoldOut", "sold_out"),
+            ("https://schema.org/OnlineOnly", "available"),
+            ("https://schema.org/LimitedAvailability", "limited"),
+            ("https://schema.org/InStock", "available"),
+        ):
+            self.assertEqual(self.avail(raw), expected, raw)
+
+    def test_silence_is_not_a_refusal(self):
+        """A source that says nothing has not said the trip is full."""
+        self.assertIsNone(self.avail(None))
+        self.assertIsNone(self.avail(""))
+        self.assertIsNone(self.avail("https://schema.org/SomethingNew"))
+
+    def test_it_reaches_the_departure(self):
+        payload = promote(
+            candidate([departure(availability="https://schema.org/SoldOut")]),
+            season=SEASON,
+        )
+        self.assertEqual(payload["departures"][0]["availability"], "sold_out")
+
+    def test_the_page_is_told_what_cannot_be_booked(self):
+        rendered = build_payload(Dataset.from_dict(promote(
+            candidate([departure(availability="https://schema.org/SoldOut")]),
+            season=SEASON,
+        )))["departures"][0]
+        self.assertFalse(rendered["bookable"])
+
+    def test_an_unknown_availability_stays_bookable(self):
+        """Hiding a trip because the source was quiet would lose real options."""
+        rendered = build_payload(Dataset.from_dict(promote(
+            candidate([departure()]), season=SEASON
+        )))["departures"][0]
+        self.assertIsNone(rendered["availability"])
+        self.assertTrue(rendered["bookable"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The scrape has carried schema.org `availability` since the first run, and `promote` dropped it on the floor.

```
746  schema.org/OnlineOnly
127  schema.org/SoldOut
 13  schema.org/LimitedAvailability
```

**127 of 886 departures were on the page priced exactly like the 746 you can still book.** On a page whose whole job is comparison that's worse than a missing column — a cheapest-first sort can put a trip nobody can buy at the top of the list.

## What's added

A **Places** column: `available` / `few left` / `sold out`, straight from the operator's own listing. Sold-out rows dim rather than disappear, and a **Hide sold out** control drops them entirely.

## Unknown stays bookable

A source that says nothing about availability has not said the trip is full. Hiding a departure on that basis would lose real options to make the page look tidier — same rule as unstated fees.

251 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_