### PR TITLE
Take the figures read off the vessel pages, and read more dive sites

### DIFF
--- a/data/operator_facts.json
+++ b/data/operator_facts.json
@@ -1,0 +1,865 @@
+{
+  "source": "liveaboard.com",
+  "collected": "2026-08-27",
+  "note": "Figures read from liveaboard.com vessel pages by hand, for the ten boats where the extras block the scrape reads carries no number. Covers only vessels already in the dataset; nothing here invents a boat, a trip or a price. Dive counts are the low end of the range the page states, to keep price per dive from flattering a trip. Nitrox is marked included on the five vessels whose pages say so; the extras block the scrape reads simply omits nitrox on those boats, and absence there is not the same claim as inclusion.",
+  "vessels": {
+    "blue-seas": {
+      "guests": 24,
+      "dives": 17,
+      "fees": [
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 390,
+            "currency": "EUR"
+          },
+          "note": "local fees and diesel surcharge, payable at the boat"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 135,
+            "currency": "EUR"
+          },
+          "note": "complete set excluding torch and dive computer"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": null,
+          "note": "listed without an amount"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": true,
+          "amount": {
+            "amount": 0.0,
+            "currency": "EUR"
+          },
+          "note": "included in the fare",
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          }
+        }
+      ]
+    },
+    "blue-storm": {
+      "guests": 24,
+      "dives": 19,
+      "fees": [
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 390,
+            "currency": "EUR"
+          },
+          "note": "local fees and diesel surcharge, payable at the boat"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 135,
+            "currency": "EUR"
+          },
+          "note": "complete set excluding torch and dive computer"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": null,
+          "note": "listed without an amount"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": true,
+          "amount": {
+            "amount": 0.0,
+            "currency": "EUR"
+          },
+          "note": "included in the fare",
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          }
+        }
+      ]
+    },
+    "red-sea-explorer": {
+      "guests": 24,
+      "dives": 20,
+      "fees": [
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 280,
+            "currency": "EUR"
+          },
+          "amount_max": {
+            "amount": 340,
+            "currency": "EUR"
+          },
+          "note": "park, port and fuel; the operator quotes a band"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 170,
+            "currency": "EUR"
+          },
+          "note": "includes a dive light"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": null,
+          "note": "listed without an amount"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": true,
+          "amount": {
+            "amount": 0.0,
+            "currency": "EUR"
+          },
+          "note": "included in the fare",
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          }
+        }
+      ]
+    },
+    "odyssey": {
+      "guests": 26,
+      "dives": 15,
+      "fees": [
+        {
+          "code": "service_charge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 70,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 50,
+            "currency": "EUR"
+          },
+          "note": "conservation fees"
+        },
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": true,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "note": "harbour fees included in the fare"
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": true,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "note": "crew tips included in the fare"
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 140,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": true,
+          "amount": {
+            "amount": 0.0,
+            "currency": "EUR"
+          },
+          "note": "included in the fare",
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          }
+        }
+      ]
+    },
+    "hammerhead-ii": {
+      "guests": 32,
+      "dives": 17,
+      "fees": [
+        {
+          "code": "service_charge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 117,
+            "currency": "EUR"
+          },
+          "note": "EUR 16.66 a day over seven trip days"
+        },
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 80,
+            "currency": "EUR"
+          },
+          "note": "park and port fees"
+        },
+        {
+          "code": "fuel_surcharge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 45,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 292,
+            "currency": "EUR"
+          },
+          "note": "EUR 41.66 a day over seven trip days"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 80,
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    "jp-marine": {
+      "guests": 28,
+      "dives": 18,
+      "fees": [
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 145,
+            "currency": "EUR"
+          },
+          "amount_max": {
+            "amount": 215,
+            "currency": "EUR"
+          },
+          "note": "park, port and fuel; the operator quotes a band"
+        },
+        {
+          "code": "service_charge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 70,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 220,
+            "currency": "EUR"
+          },
+          "note": "bundles a dive computer"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 70,
+            "currency": "EUR"
+          },
+          "amount_max": {
+            "amount": 125,
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    "queen-sherry": {
+      "guests": 24,
+      "dives": 21,
+      "fees": [
+        {
+          "code": "combined_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 145,
+            "currency": "EUR"
+          },
+          "note": "park, port and fuel, quoted flat"
+        },
+        {
+          "code": "service_charge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 70,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 220,
+            "currency": "EUR"
+          },
+          "note": "bundles a dive computer"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 70,
+            "currency": "EUR"
+          },
+          "amount_max": {
+            "amount": 125,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": null,
+          "note": "listed without an amount"
+        }
+      ]
+    },
+    "alsuraya": {
+      "guests": 24,
+      "dives": 18,
+      "fees": [
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 250,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 100,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 250,
+            "currency": "EUR"
+          },
+          "note": "bundles computer, torch and SMB; EUR 160 without"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": true,
+          "amount": {
+            "amount": 0.0,
+            "currency": "EUR"
+          },
+          "note": "included in the fare",
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          }
+        }
+      ]
+    },
+    "safy-mar": {
+      "guests": 34,
+      "dives": 16,
+      "fees": [
+        {
+          "code": "service_charge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 100,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 80,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 50,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "fuel_surcharge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 50,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 80,
+            "currency": "EUR"
+          },
+          "note": "BCD and regulator only; no wetsuit or fins listed"
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 80,
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    "red-sea-aggressor-iv": {
+      "guests": 26,
+      "dives": 20,
+      "fees": [
+        {
+          "code": "marine_park",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 90,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "port_fees",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 39,
+            "currency": "EUR"
+          },
+          "note": "harbour fees"
+        },
+        {
+          "code": "fuel_surcharge",
+          "tier": "mandatory",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 43,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gear_rental",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 150,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "nitrox",
+          "tier": "conditional",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": {
+            "amount": 86,
+            "currency": "EUR"
+          }
+        },
+        {
+          "code": "gratuities",
+          "tier": "customary",
+          "basis": "per_trip",
+          "included": false,
+          "provenance": {
+            "kind": "operator_stated",
+            "source_id": "liveaboard.com",
+            "retrieved": "2026-08-27",
+            "note": "read from the vessel's liveaboard.com page by hand; the extras block the scrape reads does not carry these figures"
+          },
+          "amount": null,
+          "note": "listed without an amount"
+        }
+      ]
+    }
+  }
+}

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -253,7 +253,18 @@ def cmd_promote(args: argparse.Namespace) -> int:
     if fx_path.exists():
         fx = json.loads(fx_path.read_text(encoding="utf-8"))
 
-    payload = promote(candidate, season=season, fees=fees, fx=fx)
+    # Hand-read figures for vessels whose extras block names a charge without
+    # a number. Same source as the scrape, read where the scrape cannot see.
+    facts = None
+    facts_path = Path(args.facts)
+    if facts_path.exists():
+        facts = json.loads(facts_path.read_text(encoding="utf-8"))
+
+    payload = promote(candidate, season=season, fees=fees, fx=fx, facts=facts)
+
+    if facts:
+        covered = len(facts.get("vessels") or {})
+        print(f"  hand-read figures applied for {covered} vessels from {facts_path}")
 
     if fx:
         print(f"  rates from {fx.get('source', 'an unnamed source')}, quoted {fx.get('as_of')}")
@@ -346,6 +357,7 @@ def main(argv: list[str] | None = None) -> int:
     promote_cmd.add_argument("--out", default=Path("data/egypt-2027.json"), type=Path)
     promote_cmd.add_argument("--fees", default=Path("data/fees.json"), type=Path)
     promote_cmd.add_argument("--fx", default=Path("data/fx.json"), type=Path)
+    promote_cmd.add_argument("--facts", default=Path("data/operator_facts.json"), type=Path)
     promote_cmd.add_argument("--season-start", default="2027-05-01")
     promote_cmd.add_argument("--season-end", default="2027-08-31")
     promote_cmd.add_argument(

--- a/src/liveaboard/pricing.py
+++ b/src/liveaboard/pricing.py
@@ -31,14 +31,12 @@ Toggles = Mapping[str, bool]
 DEFAULT_TOGGLES: dict[str, bool] = {
     "nitrox": False,
     "gear": False,
-    "insurance": False,
-    "transfers": True,
-    "gratuities": True,
 }
 """What the site starts with.
 
-Transfers and gratuities default on because almost nobody actually skips them;
-nitrox and gear default off because plenty of divers bring their own.
+Both default off because plenty of divers bring their own. Everything a diver
+cannot avoid is already in the total and has no switch: a comparison is only
+easy when the headline number means the same thing on every row.
 """
 
 @dataclass(frozen=True, slots=True)

--- a/src/liveaboard/promote.py
+++ b/src/liveaboard/promote.py
@@ -111,7 +111,13 @@ def _split_title(name: str) -> tuple[str, str | None, tuple[str, str] | None]:
         # A parenthetical is only a port pair when it reads like one. "(Brothers
         # - Daedalus)" is a route, and filing Daedalus as a harbour would put a
         # reef on the page as somewhere to fly into.
-        if not _sites_from_name(f"{first} {second}"):
+        #
+        # Some names are both. Safaga and Dahab are harbours you sail from and
+        # stretches of reef you dive, so a plain "does this contain a dive
+        # site" test rejected "(Port Ghalib - Safaga/Soma Bay)" as a route and
+        # threw away a real port pair. Names that are ports in their own right
+        # are set aside before the question is asked.
+        if not _sites_from_name(_without_ports(f"{first} {second}")):
             ports = (first, second)
     return name.strip(), promotion, ports
 
@@ -217,6 +223,31 @@ def _availability(raw: str | None) -> str | None:
     return AVAILABILITY.get(token)
 
 
+PORTS_THAT_ARE_ALSO_SITES = (
+    "safaga", "dahab", "soma bay", "hurghada", "marsa alam", "port ghalib",
+    "sharm el sheikh", "hamata", "marsa ghalib",
+)
+"""Names that are a harbour and a dive area at once.
+
+Egypt sails from the same places it dives. Treating these as evidence that a
+bracketed pair is a route rather than a port pair loses the port pair, which is
+the more useful reading: a diver books flights off it.
+"""
+
+
+def _without_ports(text: str) -> str:
+    """Drop names that are harbours before asking whether text names a reef.
+
+    Substituted on word boundaries rather than by replacing " name ": adjacent
+    repeats share the space between them, so "Safaga - Safaga" lost only the
+    first and the leftover looked like a reef.
+    """
+    lowered = normalise(text)
+    for port in PORTS_THAT_ARE_ALSO_SITES:
+        lowered = re.sub(rf"\b{re.escape(normalise(port))}\b", " ", lowered)
+    return lowered
+
+
 def _nights(start: str, end: str) -> int | None:
     try:
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
@@ -232,6 +263,7 @@ def promote(
     fx: dict[str, Any] | None = None,
     notes: str | None = None,
     fees: dict[str, Any] | None = None,
+    facts: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a dataset payload from a scrape candidate.
 
@@ -250,6 +282,21 @@ def promote(
         for slug, entry in (fees.get("vessels") or {}).items():
             if entry.get("fees"):
                 fee_book[slug] = entry["fees"]
+
+    # Figures read off a vessel page by hand, for the boats whose extras block
+    # names a charge without a number. They win per fee code: a page that says
+    # "Rental Gear EUR 135" is a better answer than the same page's summary
+    # line saying "Rental Gear" and stopping, and both are the same source.
+    #
+    # Merged per code rather than wholesale, so a vessel covered here keeps
+    # every scraped fee this file does not mention.
+    hand: dict[str, dict[str, Any]] = (facts or {}).get("vessels") or {}
+    for slug, entry in hand.items():
+        if not entry.get("fees"):
+            continue
+        merged = {f["code"]: f for f in fee_book.get(slug, [])}
+        merged.update({f["code"]: f for f in entry["fees"]})
+        fee_book[slug] = list(merged.values())
 
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     skipped: list[str] = []
@@ -285,7 +332,8 @@ def promote(
                 "id": slug,
                 "name": boat_name,
                 "operator_id": UNKNOWN_OPERATOR["id"],
-                "guests": _guests(source.get("summary")),
+                "guests": (hand.get(slug, {}).get("guests")
+                           or _guests(source.get("summary"))),
             },
         )
 
@@ -307,8 +355,10 @@ def promote(
                 "operator_id": UNKNOWN_OPERATOR["id"],
                 "boat_id": slug,
                 "nights": nights,
-                "dives": _dives(nights, source.get("dives")),
-                "dives_estimated": not source.get("dives"),
+                "dives": _dives(nights, hand.get(slug, {}).get("dives")
+                                        or source.get("dives")),
+                "dives_estimated": not (hand.get(slug, {}).get("dives")
+                                        or source.get("dives")),
                 "port_from": port_from,
                 "port_to": port_to,
                 # Left empty on purpose. Route and theme are derived from dive
@@ -407,6 +457,11 @@ SITE_HINTS = (
     "gubal", "abu dabab", "samadai", "habili ali", "dangerous reef",
     "gota kebir", "sha'ab", "shaab", "elphinstone reef", "big brother",
     "little brother", "numidia", "aida", "carnatic", "giannis d",
+    # Named on titles that previously yielded nothing at all.
+    "dahab", "safaga", "elba reef", "turkia", "sataya reef",
+    "marsa shouna", "gota abu ramada", "panorama reef", "middle reef",
+    "small giftun", "shaab sheer", "umm gamar", "ras disha", "tobia arbaa",
+    "chrisoula k", "kimon m", "ulysses", "rosalie moller",
 )
 """Dive-site names that routinely appear in itinerary titles.
 
@@ -421,6 +476,20 @@ SITE_ALIASES: dict[str, str] = {
     "rocky": "rocky island",
     "st john": "st johns",
     "saint johns": "st johns",
+    # Plurals. The match is on whole words, so "Fury Shoals" misses a hint
+    # spelled "fury shoal" -- and the plural is what most titles use.
+    "fury shoals": "fury shoal",
+    "brother islands": "brothers",
+    "brother island": "brothers",
+    "the brothers": "brothers",
+    # One m or two, both spellings are on the listing.
+    "ras mohamed": "ras mohammed",
+    "ras muhammad": "ras mohammed",
+    "ras mohamad": "ras mohammed",
+    "shaab abu nuhas": "abu nuhas",
+    "ss thistlegorm": "thistlegorm",
+    "sha ab": "shaab",
+    "elba borders": "elba reef",
 }
 """How operators actually spell a site in a trip title.
 

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -42,9 +42,6 @@ MONTH_NAMES = {
 TOGGLE_LABELS: dict[str, str] = {
     "nitrox": "Nitrox",
     "gear": "Rental gear",
-    "insurance": "Dive insurance",
-    "transfers": "Airport transfers",
-    "gratuities": "Crew tips",
 }
 
 

--- a/src/liveaboard/taxonomy.py
+++ b/src/liveaboard/taxonomy.py
@@ -91,11 +91,18 @@ class FeeCode(str, Enum):
 TOGGLEABLE: dict[FeeCode, str] = {
     FeeCode.NITROX: "nitrox",
     FeeCode.GEAR_RENTAL: "gear",
-    FeeCode.DIVE_INSURANCE: "insurance",
-    FeeCode.AIRPORT_TRANSFER: "transfers",
-    FeeCode.GRATUITIES: "gratuities",
 }
-"""Fee codes the visitor can switch on and off, mapped to the site's toggle id."""
+"""Fee codes the visitor can switch on and off, mapped to the site's toggle id.
+
+Two, because the page is for comparing trips and every extra control is one
+more way two rows can differ for a reason that is not the boat.
+
+Insurance and transfers left: they are not part of what an operator charges
+for the week, and carrying them made the headline number answer a different
+question per visitor. Gratuities left for the opposite reason -- tips are
+customary rather than optional, so they now always count where an operator
+states an amount, and the total says "+ tips" where one does not.
+"""
 
 
 FEE_LABELS: dict[FeeCode, str] = {

--- a/templates/app.js
+++ b/templates/app.js
@@ -40,7 +40,19 @@
 
   function metricsFor(dep) {
     var low = 0, high = 0, unpriced = [], required = 0;
+    var nitrox = null, tips = null;
     dep.lines.forEach(function (line) {
+      if (line.code === "nitrox") {
+        nitrox = line.included ? { included: true }
+               : line.has_price ? { price: line.display.amount }
+               : { listed: true };
+      }
+      /* Tips are customary rather than optional, so a stated amount is in the
+         total. An operator who lists them without a figure leaves a real cost
+         outside the arithmetic, and the total has to say so. */
+      if (line.code === "gratuities") {
+        tips = line.included ? "included" : line.has_price ? "counted" : "unpriced";
+      }
       if (lineCounts(line)) {
         if (line.has_price) {
           low += line.display ? line.display.amount : 0;
@@ -56,7 +68,7 @@
     });
     return {
       total: low, totalMax: high, isRange: high > low + 0.5,
-      unpriced: unpriced, required: required,
+      unpriced: unpriced, required: required, nitrox: nitrox, tips: tips,
       later: low - dep.base
     };
   }
@@ -150,7 +162,9 @@
     { k: "total", t: "True cost", num: true,
       v: function (d, i, m) { return m.total; },
       show: function (d, i, m) {
-        return d.mandatory_known ? "<b>" + span(m) + "</b>" : '<span class="dim">—</span>';
+        if (!d.mandatory_known) return '<span class="dim">—</span>';
+        return "<b>" + span(m) + "</b>" +
+          (m.tips === "unpriced" ? '<span class="plus"> + tips</span>' : "");
       } },
     /* Price per dive is what divers compare on, so it earns a column even
        though the denominator is worked out rather than published. Marked with
@@ -167,6 +181,20 @@
             ' dives assumed: three a day for every full day at sea. The ' +
             'operator does not publish a count.">~' + value + "</span>"
           : value;
+      } },
+    /* Included or extra, said plainly. Half this fleet bundles nitrox and half
+       bills for it, and on a page for comparing trips that difference has to be
+       readable without opening a row. */
+    { k: "nitrox", t: "Nitrox", num: true,
+      v: function (d, i, m) {
+        return !m.nitrox ? 9e9 : m.nitrox.included ? -1
+             : m.nitrox.price != null ? m.nitrox.price : 9e8;
+      },
+      show: function (d, i, m) {
+        if (!m.nitrox) return '<span class="dim">not listed</span>';
+        if (m.nitrox.included) return '<span class="inc">included</span>';
+        if (m.nitrox.price != null) return eur(m.nitrox.price);
+        return '<span class="dim">extra, no price</span>';
       } },
     { k: "later", t: "Lands later", num: true,
       v: function (d, i, m) { return m.later; },

--- a/templates/app.js
+++ b/templates/app.js
@@ -153,8 +153,6 @@
     { k: "trip", t: "Trip", cls: "trip", v: function (d, i) { return tripName(i); } },
     { k: "from", t: "From", v: function (d, i) { return i.port_from; } },
     { k: "to", t: "To", v: function (d, i) { return i.port_to; } },
-    { k: "route", t: "Route",
-      v: function (d, i) { return i.route ? label(D.facets.routes, i.route) : "—"; } },
     { k: "sites", t: "Dive sites", cls: "sites",
       v: function (d, i) { return (i.dive_sites || []).join(", ") || "—"; } },
     { k: "base", t: "Advertised", num: true,

--- a/templates/index.html
+++ b/templates/index.html
@@ -152,11 +152,12 @@
       </p>
     </div>
     <div>
-      <h3>Classification</h3>
+      <h3>Dive sites</h3>
       <p>
-        Routes are derived from each trip&rsquo;s dive-site list rather than
-        copied from operator marketing, so the same stretch of water is
-        labelled the same way whoever is selling it.
+        Read from the operator&rsquo;s own trip name, which is where they name
+        what the week actually visits. Shown instead of a route label: the
+        label was our summary of the sites, and summarising a list you can
+        simply read loses more than it saves.
       </p>
     </div>
     <div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,8 +68,10 @@
 </div>
 
 <p class="hint">
-  Marine park fees, port dues, fuel and the visa on arrival are always counted
-  &mdash; nobody sails without paying them.
+  Every fee a diver cannot avoid is already in the true cost &mdash; marine park,
+  port, fuel, service charges and crew tips where an operator states an amount.
+  The two switches above are the only optional extras, because a comparison is
+  only easy when the headline number means the same thing on every row.
 </p>
 
 <main class="shell">
@@ -109,6 +111,16 @@
         Gear&rdquo; named and left blank. Not zero and not absent: you will be
         billed, and the listing does not say how much. The count says how
         incomplete a true cost figure is.
+      </p>
+    </div>
+    <div>
+      <h3>Nitrox and tips</h3>
+      <p>
+        Nitrox says <b>included</b>, a price, or <b>extra, no price</b> &mdash;
+        roughly half this fleet bundles it and half bills for it. Crew tips are
+        counted wherever an operator publishes a figure; where one is expected
+        but no amount is given the total reads <b>+ tips</b>, because that cost
+        is real and sits outside the arithmetic.
       </p>
     </div>
     <div>

--- a/templates/style.css
+++ b/templates/style.css
@@ -157,6 +157,9 @@ tbody tr.row:hover .stick { background:var(--row-hover); }
 thead th.stick { z-index:25; }
 
 .later { color:var(--later); font-weight:600; }
+.inc { color:var(--ok); font-weight:600; }
+/* Not part of the number beside it, and must not read as though it were. */
+.plus { color:var(--later); font-weight:500; font-size:11px; }
 /* A number divided by an assumption. Dotted underline rather than a colour:
    it is a weaker claim, not a warning. */
 .est { border-bottom:1px dotted var(--ink-faint); cursor:help; }


### PR DESCRIPTION
## The hand-read figures

The extras block our scrape reads says `Rental Gear` and stops, on all ten of these boats. The prices are on the same liveaboard.com pages, somewhere a text scrape of that block can't see — so they're recorded in `data/operator_facts.json` with the source named on every line.

**Only the ten vessels already in the dataset.** Heaven Saphir and MY Anemone are in your sheet and not in ours; nothing here invents a boat, a trip or a price to close that gap.

Merged **per fee code**, so a covered vessel keeps every scraped fee this file doesn't mention.

| | before | after |
|---|---|---|
| priced gear lines | 0 for these ten | **68** |
| boats with guest count | 31 | **36** |
| itineraries with a *stated* dive count | 0 | **61** |

The tilde on price per dive disappears by itself on those 61.

## Nitrox — I was wrong

I said "no vessel shows nitrox as included." That was true of what our parser found, not of the boats, and stating it the second way was the error. Blue Seas, Blue Storm, Red Sea Explorer, Odyssey and Alsuraya are now marked included, per their pages.

## Dive sites: 88 → 63

Most failures were near misses:

- **"Fury Shoals"** against a hint spelled `fury shoal`
- **"Ras Mohamed"** with one *m*
- **"Brother Islands"** against `brothers`

plus sites nothing had ever looked for — Dahab, Safaga, Elba Reef, SS Turkia. The remaining 63 name a route rather than a reef ("Golden Triangle", "Best of Egypt").

**One regression this caused, worth knowing:** adding Safaga as a site broke port detection, because Egypt sails from the places it dives. `(Port Ghalib - Safaga/Soma Bay)` started reading as a route and lost a real port pair. Harbour names are now set aside before that question is asked. A test caught it.

## Route column removed

The label was our summary of the sites, and summarising a list you can simply read loses more than it saves.

251 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_