### PR TITLE
Group the guest count with the boat, not with the route

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -35,6 +35,7 @@
   --st1:82px;   /* Depart */
   --st2:78px;   /* Return */
   --st3:132px;  /* Boat   */
+  --st4:62px;   /* Guests */
 
   /* Fonts the visitor already has.
    *
@@ -245,7 +246,7 @@ tbody tr.row:hover { background:var(--row-hover); }
 /* The pinned columns: at twenty columns, when and on what is what identifies a
    row, and a row that scrolls away from its own dates and boat cannot be
    compared with anything. */
-.stick1, .stick2, .stick3 {
+.stick1, .stick2, .stick3, .stick4 {
   position:sticky; z-index:10; background:var(--panel);
   overflow:hidden; text-overflow:ellipsis;
 }
@@ -260,14 +261,24 @@ tbody tr.row:hover { background:var(--row-hover); }
   left:calc(var(--st0) + var(--st1) + var(--st2));
   width:var(--st3); min-width:var(--st3); max-width:var(--st3);
 }
-.stick3, .pins-2 .stick2 { border-right:1px solid var(--rule-strong); }
-tbody tr.row.alt .stick1, tbody tr.row.alt .stick2, tbody tr.row.alt .stick3 {
-  background:var(--row-alt);
+.stick4 {
+  left:calc(var(--st0) + var(--st1) + var(--st2) + var(--st3));
+  width:var(--st4); min-width:var(--st4); max-width:var(--st4);
 }
-tbody tr.row:hover .stick1, tbody tr.row:hover .stick2, tbody tr.row:hover .stick3 {
-  background:var(--row-hover);
+/* The rule that closes the pinned group sits on whichever column ends it. */
+.pins-4 .stick4, .pins-3 .stick3, .pins-2 .stick2 {
+  border-right:1px solid var(--rule-strong);
 }
-thead th.stick1, thead th.stick2, thead th.stick3 { z-index:25; }
+/* And a lighter one inside it, between when the trip runs and what it runs on.
+   Guests is a fact about the vessel -- how many people you are sharing a dive
+   deck with -- so it belongs on the boat's side of that line, not at the head
+   of the route columns where the pinned edge used to leave it. */
+.stick3 { border-left:1px solid var(--rule); }
+tbody tr.row.alt .stick1, tbody tr.row.alt .stick2,
+tbody tr.row.alt .stick3, tbody tr.row.alt .stick4 { background:var(--row-alt); }
+tbody tr.row:hover .stick1, tbody tr.row:hover .stick2,
+tbody tr.row:hover .stick3, tbody tr.row:hover .stick4 { background:var(--row-hover); }
+thead th.stick1, thead th.stick2, thead th.stick3, thead th.stick4 { z-index:25; }
 
 /* The control that opens the bill, at the start of the row and pinned with the
    columns that identify it.
@@ -1069,7 +1080,8 @@ a { color:var(--accent); }
      a column that silently vanished would be a fact the page stopped
      publishing. */
   var ORDER = [
-    "start", "end", "boat", "guests", "from", "to", "trip",
+    "start", "end", "boat", "guests",
+    "from", "to", "trip",
     "total", "later", "base", "perdive", "nitrox", "sites",
     "required", "availability", "disclosure", "source"
   ];
@@ -1117,13 +1129,24 @@ a { color:var(--accent); }
      two pinned columns with a third between them overlap exactly as badly as
      two with a wrong offset, and naming them let that happen the moment the
      order changed. Three fit a laptop; on a phone 82 + 78 + 132 would be three
-     quarters of the screen, so a phone pins two and Return scrolls. */
-  function pinned() { return narrow.matches ? 2 : 3; }
+     quarters of the screen, so a phone pins two and Return scrolls.
+
+     Four on a wide screen, because Guests is a fact about the vessel -- how
+     many people you share a dive deck with -- and the pinned group's closing
+     rule is what says where the identity columns end. Left at three, that rule
+     fell between Boat and Guests and filed the guest count as the first of the
+     route columns. It is on the boat's side of it now. */
+  function pinned() {
+    return narrow.matches ? 2 : compact.matches ? 3 : 4;
+  }
 
   function orderColumns() {
     /* The rule that closes the pinned group goes on whichever column is last
        in it, and that changes with the breakpoint. */
-    document.body.classList.toggle("pins-2", narrow.matches);
+    var n = pinned();
+    document.body.classList.toggle("pins-2", n === 2);
+    document.body.classList.toggle("pins-3", n === 3);
+    document.body.classList.toggle("pins-4", n === 4);
     var order = narrow.matches ? PHONE_ORDER
               : compact.matches ? COMPACT_ORDER : ORDER;
     COLS.sort(function (a, b) {

--- a/templates/app.js
+++ b/templates/app.js
@@ -347,7 +347,8 @@
      a column that silently vanished would be a fact the page stopped
      publishing. */
   var ORDER = [
-    "start", "end", "boat", "guests", "from", "to", "trip",
+    "start", "end", "boat", "guests",
+    "from", "to", "trip",
     "total", "later", "base", "perdive", "nitrox", "sites",
     "required", "availability", "disclosure", "source"
   ];
@@ -395,13 +396,24 @@
      two pinned columns with a third between them overlap exactly as badly as
      two with a wrong offset, and naming them let that happen the moment the
      order changed. Three fit a laptop; on a phone 82 + 78 + 132 would be three
-     quarters of the screen, so a phone pins two and Return scrolls. */
-  function pinned() { return narrow.matches ? 2 : 3; }
+     quarters of the screen, so a phone pins two and Return scrolls.
+
+     Four on a wide screen, because Guests is a fact about the vessel -- how
+     many people you share a dive deck with -- and the pinned group's closing
+     rule is what says where the identity columns end. Left at three, that rule
+     fell between Boat and Guests and filed the guest count as the first of the
+     route columns. It is on the boat's side of it now. */
+  function pinned() {
+    return narrow.matches ? 2 : compact.matches ? 3 : 4;
+  }
 
   function orderColumns() {
     /* The rule that closes the pinned group goes on whichever column is last
        in it, and that changes with the breakpoint. */
-    document.body.classList.toggle("pins-2", narrow.matches);
+    var n = pinned();
+    document.body.classList.toggle("pins-2", n === 2);
+    document.body.classList.toggle("pins-3", n === 3);
+    document.body.classList.toggle("pins-4", n === 4);
     var order = narrow.matches ? PHONE_ORDER
               : compact.matches ? COMPACT_ORDER : ORDER;
     COLS.sort(function (a, b) {

--- a/templates/style.css
+++ b/templates/style.css
@@ -28,6 +28,7 @@
   --st1:82px;   /* Depart */
   --st2:78px;   /* Return */
   --st3:132px;  /* Boat   */
+  --st4:62px;   /* Guests */
 
   /* Fonts the visitor already has.
    *
@@ -238,7 +239,7 @@ tbody tr.row:hover { background:var(--row-hover); }
 /* The pinned columns: at twenty columns, when and on what is what identifies a
    row, and a row that scrolls away from its own dates and boat cannot be
    compared with anything. */
-.stick1, .stick2, .stick3 {
+.stick1, .stick2, .stick3, .stick4 {
   position:sticky; z-index:10; background:var(--panel);
   overflow:hidden; text-overflow:ellipsis;
 }
@@ -253,14 +254,24 @@ tbody tr.row:hover { background:var(--row-hover); }
   left:calc(var(--st0) + var(--st1) + var(--st2));
   width:var(--st3); min-width:var(--st3); max-width:var(--st3);
 }
-.stick3, .pins-2 .stick2 { border-right:1px solid var(--rule-strong); }
-tbody tr.row.alt .stick1, tbody tr.row.alt .stick2, tbody tr.row.alt .stick3 {
-  background:var(--row-alt);
+.stick4 {
+  left:calc(var(--st0) + var(--st1) + var(--st2) + var(--st3));
+  width:var(--st4); min-width:var(--st4); max-width:var(--st4);
 }
-tbody tr.row:hover .stick1, tbody tr.row:hover .stick2, tbody tr.row:hover .stick3 {
-  background:var(--row-hover);
+/* The rule that closes the pinned group sits on whichever column ends it. */
+.pins-4 .stick4, .pins-3 .stick3, .pins-2 .stick2 {
+  border-right:1px solid var(--rule-strong);
 }
-thead th.stick1, thead th.stick2, thead th.stick3 { z-index:25; }
+/* And a lighter one inside it, between when the trip runs and what it runs on.
+   Guests is a fact about the vessel -- how many people you are sharing a dive
+   deck with -- so it belongs on the boat's side of that line, not at the head
+   of the route columns where the pinned edge used to leave it. */
+.stick3 { border-left:1px solid var(--rule); }
+tbody tr.row.alt .stick1, tbody tr.row.alt .stick2,
+tbody tr.row.alt .stick3, tbody tr.row.alt .stick4 { background:var(--row-alt); }
+tbody tr.row:hover .stick1, tbody tr.row:hover .stick2,
+tbody tr.row:hover .stick3, tbody tr.row:hover .stick4 { background:var(--row-hover); }
+thead th.stick1, thead th.stick2, thead th.stick3, thead th.stick4 { z-index:25; }
 
 /* The control that opens the bill, at the start of the row and pinned with the
    columns that identify it.


### PR DESCRIPTION
Guests is a fact about the vessel — how many people you are sharing a dive deck with — and it was reading as the first of the route columns.

Not because of where it sat, which was already beside Boat, but because of where the *line* was: the pinned group's closing rule fell between the two, so the eye grouped Guests with From, To and Trip on the far side of it.

So the rule moves, not the column. Guests joins the pinned group on a wide screen, which puts the strong rule after it, and a lighter one opens before Boat. The header now reads as four groups instead of a run of columns:

```
 +  │ 01 May   08 May │ ALSURAYA        24 │ Hurghada  Port Ghalib  Brothers, Daedalus… │ €1,566
    │ DEPART   RETURN │ BOAT        GUESTS │ FROM      TO           TRIP                │ TRUE COST
      when              what it is on        where it goes                                what it costs
```

Below 1100px the compact order puts the money straight after the identity and Guests is no longer adjacent to Boat, so three columns pin there and two on a phone. The pinned group is now always exactly the identity columns of whichever order is being rendered, rather than a fixed count that can land mid-group.

Measured at eight widths from 390 to 1920: no pinned overlap, True cost on screen at every one, no page-level horizontal overflow. 390 tests, dataset valid, `promote --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_