### PR TITLE
Carry the column decisions onto the phone, and correct what the page says about nitrox

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -500,7 +500,12 @@ a { color:var(--accent); }
   :root { --st0:24px; --st1:66px; --st2:96px; }
 
   td.expander, th.expander { padding:4px 6px; }
-  tbody td, thead th { padding:6px 7px; }
+  /* 6px, not 7. Guests moved in front of the money here to sit with the boat,
+     and its 49px put the Total's right edge 4px past a 390px screen -- which
+     clipped the "+ tips" that says the total is not the whole bill. Two pixels
+     a side on the one unpinned column ahead of the price, and two off the
+     price column's own padding, is the whole difference. */
+  tbody td, thead th { padding:6px 5px; }
   /* One line each, ellipsised, on this screen only. Both columns sit behind
      the horizontal scroll here, yet their wrapping still set the height of
      every row: rows ran 35 to 88px and the tallest of them pushed six rows of
@@ -515,9 +520,9 @@ a { color:var(--accent); }
   /* "DEPART ▲" needs 74px of the 66 the pinned date column has here, and a
      header that reads "DEPAR…" is worse than a slightly smaller one. */
   thead th { font-size:9px; letter-spacing:.04em; }
-  /* Cell padding is 7px here, not 9, and the bar has to end where the number
+  /* Cell padding is 5px here, not 9, and the bar has to end where the number
      above it ends. */
-  .anchor { right:7px; }
+  .anchor { right:5px; }
   .site-footer { max-height:60vh; }
 }
 </style>
@@ -1155,12 +1160,60 @@ a { color:var(--accent); }
     "base", "nitrox", "later", "total", "perdive",
     "availability", "disclosure", "source"
   ];
-  /* The same columns on a phone, reordered again.
-     A phone shows about two columns beside the two pinned ones, and on the
-     desktop order those two were Nts and Trip -- so the table opened on a trip
-     title and you scrolled 600px to find out what it cost. Here the money
-     comes first and the descriptive columns sit behind it: nothing is hidden,
-     the reading order is just inverted to match how much screen there is. */
+  /* The same columns on a phone, and as much of the same order as 390px holds.
+     Three of the four rules above survive here unchanged: no Operator or
+     Nights column, Guests grouped with the Boat, and Dive sites straight after
+     Trip. The fourth -- the price block reading Advertised, Nitrox, Mandatory
+     fees, Total -- cannot, and the note on the block below says what it costs.
+
+     What does not fit in front of the money, measured at 390px: Return is
+     62px, From and To are 120px each, and the pinned pair plus the expander
+     already spend 186. Return therefore follows the money rather than leading
+     it, as it does nowhere else. Of the two identifiers, the boat's name is
+     what a row is compared by; the return date you read once you have found
+     the row. Nothing is dropped -- the order is what changes. */
+  var PHONE_ORDER = [
+    /* Guests sits with the boat here, as it does at every other width: how
+       many people share the dive deck is a fact about the vessel, not about
+       the route. It is the one descriptive column that fits in front of the
+       money -- 45px, against 62 for Return and 120 for From. */
+    "start", "boat", "guests",
+    /* The one place the bill order gives way, and only in its first term.
+       Everywhere else the prices read Advertised, Nitrox, Mandatory fees,
+       Total, which is the order a bill is read in and the order the footer
+       explains. A phone cannot have it: measured at 390px, the three parts
+       ahead of the Total put the Total's left edge at x=1247 on the wide
+       order and x=477 even with nothing but the pinned columns before them.
+       The number this page exists to publish would be off the edge on the
+       device most people open it on.
+       So the Total leads and its parts follow it, in the bill's own order --
+       Advertised, Nitrox, Mandatory fees -- rather than in a third order
+       invented for this width. Scrolling right reads the bill; not scrolling
+       still shows the answer. */
+    "total", "base", "nitrox", "later", "perdive",
+    "end", "from", "to", "trip", "sites",
+    "availability", "disclosure", "source"
+  ];
+
+  /* The same again on a screen too small to afford Guests in front of the
+     money. Guests is 45px and the Total is 155 behind 186px of expander and
+     pinned columns, so the Total's right edge lands at 386: fine on a 390px
+     phone and 26px past the edge of a 360px one, which is a Galaxy S-series
+     and most older Androids. Measured, not assumed -- putting Guests ahead of
+     the price took the Total from 186..345 to 231..386.
+
+     So below that width Guests goes back behind the price block, at the head
+     of the descriptive columns rather than buried among them. The money is
+     the one thing that cannot move: a Total off the right-hand edge is the
+     exact failure this whole ordering exists to prevent, and it would be
+     silent -- the row still renders, it just does not answer the question. */
+  var TINY_ORDER = [
+    "start", "boat",
+    "total", "base", "nitrox", "later", "perdive",
+    "guests", "end", "from", "to", "trip", "sites",
+    "availability", "disclosure", "source"
+  ];
+
   /* The same columns, and the same price order within them, wherever there is
      not room for the reading order above. Identity, then the money, then
      everything the money is for.
@@ -1172,25 +1225,6 @@ a { color:var(--accent); }
      1440px laptop, which is most of them. Below that the price block moves in
      front of the descriptive columns -- Advertised, Nitrox, Mandatory fees,
      Total, in that order still. */
-  /* A phone fits the expander, two pinned columns and the price, and nothing
-     else before it: 24 + 66 + 96 + 160 is 346 of 390. A third pinned column
-     makes 412, and Return merely sitting third rather than pinned still makes
-     424 -- either way the number the page exists to show is off the edge.
-     So here Return follows the money rather than leading it. Of the two
-     identifiers, the boat's name is what a row is compared by; the return date
-     you read once you have found the row. */
-  var PHONE_ORDER = [
-    "start", "boat",
-    /* The one place the bill order gives way. A phone fits the expander, two
-       pinned columns and one price: Advertised, Nitrox and Mandatory fees
-       ahead of the Total put it at x 436 of a 390px screen. The Total is what
-       one row is compared with another by, so here it leads and its parts
-       follow it. */
-    "total", "later", "base", "nitrox", "perdive",
-    "end", "guests", "from", "to", "trip", "sites",
-    "availability", "disclosure", "source"
-  ];
-
   var COMPACT_ORDER = [
     "start", "end", "boat",
     "base", "nitrox", "later", "total", "perdive",
@@ -1203,6 +1237,11 @@ a { color:var(--accent); }
      and drives the pinned-column widths and the folded filter banks. */
   var compact = window.matchMedia("(max-width: 1700px)");
   var narrow = window.matchMedia("(max-width: 760px)");
+  /* A third question, and the narrowest one: is there room for a descriptive
+     column in front of the price at all? 385 is where the measurement falls,
+     not a round number chosen first -- Guests ahead of the money puts the
+     Total's right edge at 386. */
+  var tiny = window.matchMedia("(max-width: 385px)");
 
   /* How many of the leading columns are pinned. By position, never by name:
      two pinned columns with a third between them overlap exactly as badly as
@@ -1226,19 +1265,26 @@ a { color:var(--accent); }
     document.body.classList.toggle("pins-2", n === 2);
     document.body.classList.toggle("pins-3", n === 3);
     document.body.classList.toggle("pins-4", n === 4);
-    var order = narrow.matches ? PHONE_ORDER
+    var order = tiny.matches ? TINY_ORDER
+              : narrow.matches ? PHONE_ORDER
               : compact.matches ? COMPACT_ORDER : ORDER;
     COLS.sort(function (a, b) {
       var x = order.indexOf(a.k), y = order.indexOf(b.k);
       return (x < 0 ? order.length : x) - (y < 0 ? order.length : y);
     });
   }
+  /* Appended rather than dropped, and said out loud: a column missing from one
+     of these lists is a fact the page stops publishing at that width only,
+     which is the hardest kind of gap to notice -- the laptop everyone develops
+     on would look right. So every list is checked, not just the widest. */
   COLS.forEach(function (c) {
-    /* Appended rather than dropped, and said out loud: a column that quietly
-       vanished from both lists would be a fact the page stopped publishing. */
-    if (ORDER.indexOf(c.k) < 0 && window.console) {
-      console.warn("column " + c.k + " is not in ORDER; printed last");
-    }
+    [["ORDER", ORDER], ["COMPACT_ORDER", COMPACT_ORDER],
+     ["PHONE_ORDER", PHONE_ORDER], ["TINY_ORDER", TINY_ORDER]
+    ].forEach(function (pair) {
+      if (pair[1].indexOf(c.k) < 0 && window.console) {
+        console.warn("column " + c.k + " is not in " + pair[0] + "; printed last");
+      }
+    });
   });
   orderColumns();
 
@@ -1588,7 +1634,7 @@ a { color:var(--accent); }
   /* Rotating the device changes which order the columns should be in, and a
      table left in the other one is the bug this exists to prevent. */
   var onWidthChange = function () { orderColumns(); draw(); };
-  [compact, narrow].forEach(function (mq) {
+  [compact, narrow, tiny].forEach(function (mq) {
     if (mq.addEventListener) mq.addEventListener("change", onWidthChange);
     else if (mq.addListener) mq.addListener(onWidthChange);
   });

--- a/site/index.html
+++ b/site/index.html
@@ -497,7 +497,24 @@ a { color:var(--accent); }
      would leave a row that scrolls away from either its dates or its boat. At
      66 + 66 + 96 they take 228px of 390 and True cost, the next column, lands
      inside the remaining 162. */
-  :root { --st0:24px; --st1:66px; --st2:96px; }
+  /* Three here, not two: Depart, Boat and Guests. Guests joined the identity
+     columns in the order, and a group is only a group if the rule that closes
+     it falls after the last of them -- left pinned at two, the strong edge
+     landed between Boat and Guests and filed the guest count with the money,
+     which is the same mistake the wide table made before Guests was pinned
+     there. 24 + 66 + 96 + 45 is 231 of 390, and the Total still lands whole
+     inside what is left. Below 386px Guests is not in front of the money at
+     all, so the count drops back to two -- see `pinned()`. */
+  :root { --st0:24px; --st1:66px; --st2:96px; --st3:45px; }
+
+  /* The group rules, by what the columns mean rather than by where they sit.
+     On a wide screen the light rule falls on `.stick3`, because the pinned
+     four are Depart, Return, Boat, Guests and Boat is third. Here the pinned
+     three are Depart, Boat, Guests, so Boat is second and Guests is third:
+     the light rule moves to `.stick2` and must come off `.stick3`, or it
+     would split the boat from its own guest count. */
+  .stick2 { border-left:1px solid var(--rule); }
+  .stick3 { border-left:0; }
 
   td.expander, th.expander { padding:4px 6px; }
   /* 6px, not 7. Guests moved in front of the money here to sit with the boat,
@@ -992,7 +1009,7 @@ a { color:var(--accent); }
        boat of twelve or of thirty-four. Null where the description does not
        state it — about half the fleet, which is a gap in the scrape rather
        than an operator declining to say. */
-    { k: "guests", t: "Guests", num: true,
+    { k: "guests", t: "Guests", short: "Pax", num: true,
       v: function (d, i) { return i.guests == null ? -1 : i.guests; },
       show: function (d, i) {
         return i.guests == null ? '<span class="dim">—</span>' : i.guests;
@@ -1253,9 +1270,20 @@ a { color:var(--accent); }
      many people you share a dive deck with -- and the pinned group's closing
      rule is what says where the identity columns end. Left at three, that rule
      fell between Boat and Guests and filed the guest count as the first of the
-     route columns. It is on the boat's side of it now. */
+     route columns. It is on the boat's side of it now.
+
+     Three on a phone for the same reason and not a different one. Guests sits
+     with the boat in PHONE_ORDER, so pinning two would put the closing rule
+     between them and undo on a phone exactly what the fourth pin fixed on a
+     desktop -- the group would say the guest count belongs to the money. Here
+     the three are Depart, Boat, Guests: 24 + 66 + 96 + 45 of 390, with the
+     Total whole in what remains.
+
+     Two below 386px, where Guests is behind the money rather than in front of
+     it (see TINY_ORDER). Pinning it there would freeze 59% of the screen to
+     hold a column that is not even next to the boat any more. */
   function pinned() {
-    return narrow.matches ? 2 : compact.matches ? 3 : 4;
+    return tiny.matches ? 2 : narrow.matches ? 3 : compact.matches ? 3 : 4;
   }
 
   function orderColumns() {
@@ -1397,8 +1425,18 @@ a { color:var(--accent); }
       COLS.map(function (c, n) {
       var dir = c.k === state.sort
         ? '<span class="dir">' + (state.dir > 0 ? "▲" : "▼") + "</span>" : "";
+      /* The short label where one is set and the screen is narrow. A pinned
+         column is a fixed width, and "GUESTS" wants 65px of the 45 it has
+         there -- so the choice is a header reading "GUES…" or a shorter word
+         that is whole. The same call the date column already made when it
+         took a smaller font rather than print "DEPAR…": a truncated value can
+         be read as truncated, a truncated column name cannot. */
+      var label = (narrow.matches && c.short) ? c.short : c.t;
+      /* The tooltip only where the word was shortened, so it names the column
+         rather than repeating it. */
+      var full = label === c.t ? "" : ' title="' + esc(c.t) + '"';
       return '<th tabindex="0" class="' + (c.num ? "num " : "") + pin(n) +
-        '" data-k="' + c.k + '">' + c.t + " " + dir + "</th>";
+        '" data-k="' + c.k + '"' + full + ">" + label + " " + dir + "</th>";
     }).join("") + "</tr>";
 
     document.getElementById("body").innerHTML = rows.length

--- a/site/index.html
+++ b/site/index.html
@@ -721,11 +721,18 @@ a { color:var(--accent); }
     <div>
       <h3>Nitrox and tips</h3>
       <p>
-        Nitrox says <b>included</b>, a price, or <b>extra, no price</b> &mdash;
-        roughly half this fleet bundles it and half bills for it. Crew tips are
-        counted wherever an operator publishes a figure; where one is expected
-        but no amount is given the total reads <b>+ tips</b>, because that cost
-        is real and sits outside the arithmetic.
+        Two thirds of this fleet bundles nitrox and a third bills for it:
+        <b>44</b> vessels say <b>included</b>, <b>21</b> publish a price
+        &mdash; &euro;30 to &euro;100, most often around &euro;77 a week
+        &mdash; and <b>2</b> never mention it at all. Those two read
+        <b>not listed</b>, which is the one thing on this page nitrox can say
+        that is neither yes nor a number: nobody has said whether you will be
+        charged.
+      </p>
+      <p>
+        Crew tips are counted wherever an operator publishes a figure; where
+        one is expected but no amount is given the total reads <b>+ tips</b>,
+        because that cost is real and sits outside the arithmetic.
       </p>
     </div>
     <div>
@@ -1090,9 +1097,19 @@ a { color:var(--accent); }
                'or spend longer in the parks where night dives are not ' +
                'allowed, fit fewer in.">↓ ' + i.dives + "+</span>";
       } },
-    /* Included or extra, said plainly. Half this fleet bundles nitrox and half
-       bills for it, and on a page for comparing trips that difference has to be
-       readable without opening a row. */
+    /* Included or extra, said plainly. Two thirds of this fleet bundles nitrox
+       and a third bills for it -- 44 vessels against 21 -- and on a page for
+       comparing trips that difference has to be readable without opening a row.
+
+       Four answers, of which three occur. "not listed" is two vessels whose
+       extras block never mentions nitrox: not free, not priced, unknown. The
+       fourth -- a nitrox line that is neither included nor priced, the way
+       "Rental Gear" is routinely named with no figure -- currently matches
+       nothing. It stays because without it the function returns undefined and
+       the cell would print that word rather than an answer, and because the
+       gear case proves an operator can list an extra and leave the number
+       blank. A branch nothing reaches yet is cheaper than a cell reading
+       "undefined" on the day one does. */
     { k: "nitrox", t: "Nitrox", num: true,
       v: function (d, i, m) {
         return !m.nitrox ? 9e9 : m.nitrox.included ? -1

--- a/templates/app.js
+++ b/templates/app.js
@@ -199,7 +199,7 @@
        boat of twelve or of thirty-four. Null where the description does not
        state it — about half the fleet, which is a gap in the scrape rather
        than an operator declining to say. */
-    { k: "guests", t: "Guests", num: true,
+    { k: "guests", t: "Guests", short: "Pax", num: true,
       v: function (d, i) { return i.guests == null ? -1 : i.guests; },
       show: function (d, i) {
         return i.guests == null ? '<span class="dim">—</span>' : i.guests;
@@ -460,9 +460,20 @@
      many people you share a dive deck with -- and the pinned group's closing
      rule is what says where the identity columns end. Left at three, that rule
      fell between Boat and Guests and filed the guest count as the first of the
-     route columns. It is on the boat's side of it now. */
+     route columns. It is on the boat's side of it now.
+
+     Three on a phone for the same reason and not a different one. Guests sits
+     with the boat in PHONE_ORDER, so pinning two would put the closing rule
+     between them and undo on a phone exactly what the fourth pin fixed on a
+     desktop -- the group would say the guest count belongs to the money. Here
+     the three are Depart, Boat, Guests: 24 + 66 + 96 + 45 of 390, with the
+     Total whole in what remains.
+
+     Two below 386px, where Guests is behind the money rather than in front of
+     it (see TINY_ORDER). Pinning it there would freeze 59% of the screen to
+     hold a column that is not even next to the boat any more. */
   function pinned() {
-    return narrow.matches ? 2 : compact.matches ? 3 : 4;
+    return tiny.matches ? 2 : narrow.matches ? 3 : compact.matches ? 3 : 4;
   }
 
   function orderColumns() {
@@ -604,8 +615,18 @@
       COLS.map(function (c, n) {
       var dir = c.k === state.sort
         ? '<span class="dir">' + (state.dir > 0 ? "▲" : "▼") + "</span>" : "";
+      /* The short label where one is set and the screen is narrow. A pinned
+         column is a fixed width, and "GUESTS" wants 65px of the 45 it has
+         there -- so the choice is a header reading "GUES…" or a shorter word
+         that is whole. The same call the date column already made when it
+         took a smaller font rather than print "DEPAR…": a truncated value can
+         be read as truncated, a truncated column name cannot. */
+      var label = (narrow.matches && c.short) ? c.short : c.t;
+      /* The tooltip only where the word was shortened, so it names the column
+         rather than repeating it. */
+      var full = label === c.t ? "" : ' title="' + esc(c.t) + '"';
       return '<th tabindex="0" class="' + (c.num ? "num " : "") + pin(n) +
-        '" data-k="' + c.k + '">' + c.t + " " + dir + "</th>";
+        '" data-k="' + c.k + '"' + full + ">" + label + " " + dir + "</th>";
     }).join("") + "</tr>";
 
     document.getElementById("body").innerHTML = rows.length

--- a/templates/app.js
+++ b/templates/app.js
@@ -280,9 +280,19 @@
                'or spend longer in the parks where night dives are not ' +
                'allowed, fit fewer in.">↓ ' + i.dives + "+</span>";
       } },
-    /* Included or extra, said plainly. Half this fleet bundles nitrox and half
-       bills for it, and on a page for comparing trips that difference has to be
-       readable without opening a row. */
+    /* Included or extra, said plainly. Two thirds of this fleet bundles nitrox
+       and a third bills for it -- 44 vessels against 21 -- and on a page for
+       comparing trips that difference has to be readable without opening a row.
+
+       Four answers, of which three occur. "not listed" is two vessels whose
+       extras block never mentions nitrox: not free, not priced, unknown. The
+       fourth -- a nitrox line that is neither included nor priced, the way
+       "Rental Gear" is routinely named with no figure -- currently matches
+       nothing. It stays because without it the function returns undefined and
+       the cell would print that word rather than an answer, and because the
+       gear case proves an operator can list an extra and leave the number
+       blank. A branch nothing reaches yet is cheaper than a cell reading
+       "undefined" on the day one does. */
     { k: "nitrox", t: "Nitrox", num: true,
       v: function (d, i, m) {
         return !m.nitrox ? 9e9 : m.nitrox.included ? -1

--- a/templates/app.js
+++ b/templates/app.js
@@ -367,12 +367,60 @@
     "base", "nitrox", "later", "total", "perdive",
     "availability", "disclosure", "source"
   ];
-  /* The same columns on a phone, reordered again.
-     A phone shows about two columns beside the two pinned ones, and on the
-     desktop order those two were Nts and Trip -- so the table opened on a trip
-     title and you scrolled 600px to find out what it cost. Here the money
-     comes first and the descriptive columns sit behind it: nothing is hidden,
-     the reading order is just inverted to match how much screen there is. */
+  /* The same columns on a phone, and as much of the same order as 390px holds.
+     Three of the four rules above survive here unchanged: no Operator or
+     Nights column, Guests grouped with the Boat, and Dive sites straight after
+     Trip. The fourth -- the price block reading Advertised, Nitrox, Mandatory
+     fees, Total -- cannot, and the note on the block below says what it costs.
+
+     What does not fit in front of the money, measured at 390px: Return is
+     62px, From and To are 120px each, and the pinned pair plus the expander
+     already spend 186. Return therefore follows the money rather than leading
+     it, as it does nowhere else. Of the two identifiers, the boat's name is
+     what a row is compared by; the return date you read once you have found
+     the row. Nothing is dropped -- the order is what changes. */
+  var PHONE_ORDER = [
+    /* Guests sits with the boat here, as it does at every other width: how
+       many people share the dive deck is a fact about the vessel, not about
+       the route. It is the one descriptive column that fits in front of the
+       money -- 45px, against 62 for Return and 120 for From. */
+    "start", "boat", "guests",
+    /* The one place the bill order gives way, and only in its first term.
+       Everywhere else the prices read Advertised, Nitrox, Mandatory fees,
+       Total, which is the order a bill is read in and the order the footer
+       explains. A phone cannot have it: measured at 390px, the three parts
+       ahead of the Total put the Total's left edge at x=1247 on the wide
+       order and x=477 even with nothing but the pinned columns before them.
+       The number this page exists to publish would be off the edge on the
+       device most people open it on.
+       So the Total leads and its parts follow it, in the bill's own order --
+       Advertised, Nitrox, Mandatory fees -- rather than in a third order
+       invented for this width. Scrolling right reads the bill; not scrolling
+       still shows the answer. */
+    "total", "base", "nitrox", "later", "perdive",
+    "end", "from", "to", "trip", "sites",
+    "availability", "disclosure", "source"
+  ];
+
+  /* The same again on a screen too small to afford Guests in front of the
+     money. Guests is 45px and the Total is 155 behind 186px of expander and
+     pinned columns, so the Total's right edge lands at 386: fine on a 390px
+     phone and 26px past the edge of a 360px one, which is a Galaxy S-series
+     and most older Androids. Measured, not assumed -- putting Guests ahead of
+     the price took the Total from 186..345 to 231..386.
+
+     So below that width Guests goes back behind the price block, at the head
+     of the descriptive columns rather than buried among them. The money is
+     the one thing that cannot move: a Total off the right-hand edge is the
+     exact failure this whole ordering exists to prevent, and it would be
+     silent -- the row still renders, it just does not answer the question. */
+  var TINY_ORDER = [
+    "start", "boat",
+    "total", "base", "nitrox", "later", "perdive",
+    "guests", "end", "from", "to", "trip", "sites",
+    "availability", "disclosure", "source"
+  ];
+
   /* The same columns, and the same price order within them, wherever there is
      not room for the reading order above. Identity, then the money, then
      everything the money is for.
@@ -384,25 +432,6 @@
      1440px laptop, which is most of them. Below that the price block moves in
      front of the descriptive columns -- Advertised, Nitrox, Mandatory fees,
      Total, in that order still. */
-  /* A phone fits the expander, two pinned columns and the price, and nothing
-     else before it: 24 + 66 + 96 + 160 is 346 of 390. A third pinned column
-     makes 412, and Return merely sitting third rather than pinned still makes
-     424 -- either way the number the page exists to show is off the edge.
-     So here Return follows the money rather than leading it. Of the two
-     identifiers, the boat's name is what a row is compared by; the return date
-     you read once you have found the row. */
-  var PHONE_ORDER = [
-    "start", "boat",
-    /* The one place the bill order gives way. A phone fits the expander, two
-       pinned columns and one price: Advertised, Nitrox and Mandatory fees
-       ahead of the Total put it at x 436 of a 390px screen. The Total is what
-       one row is compared with another by, so here it leads and its parts
-       follow it. */
-    "total", "later", "base", "nitrox", "perdive",
-    "end", "guests", "from", "to", "trip", "sites",
-    "availability", "disclosure", "source"
-  ];
-
   var COMPACT_ORDER = [
     "start", "end", "boat",
     "base", "nitrox", "later", "total", "perdive",
@@ -415,6 +444,11 @@
      and drives the pinned-column widths and the folded filter banks. */
   var compact = window.matchMedia("(max-width: 1700px)");
   var narrow = window.matchMedia("(max-width: 760px)");
+  /* A third question, and the narrowest one: is there room for a descriptive
+     column in front of the price at all? 385 is where the measurement falls,
+     not a round number chosen first -- Guests ahead of the money puts the
+     Total's right edge at 386. */
+  var tiny = window.matchMedia("(max-width: 385px)");
 
   /* How many of the leading columns are pinned. By position, never by name:
      two pinned columns with a third between them overlap exactly as badly as
@@ -438,19 +472,26 @@
     document.body.classList.toggle("pins-2", n === 2);
     document.body.classList.toggle("pins-3", n === 3);
     document.body.classList.toggle("pins-4", n === 4);
-    var order = narrow.matches ? PHONE_ORDER
+    var order = tiny.matches ? TINY_ORDER
+              : narrow.matches ? PHONE_ORDER
               : compact.matches ? COMPACT_ORDER : ORDER;
     COLS.sort(function (a, b) {
       var x = order.indexOf(a.k), y = order.indexOf(b.k);
       return (x < 0 ? order.length : x) - (y < 0 ? order.length : y);
     });
   }
+  /* Appended rather than dropped, and said out loud: a column missing from one
+     of these lists is a fact the page stops publishing at that width only,
+     which is the hardest kind of gap to notice -- the laptop everyone develops
+     on would look right. So every list is checked, not just the widest. */
   COLS.forEach(function (c) {
-    /* Appended rather than dropped, and said out loud: a column that quietly
-       vanished from both lists would be a fact the page stopped publishing. */
-    if (ORDER.indexOf(c.k) < 0 && window.console) {
-      console.warn("column " + c.k + " is not in ORDER; printed last");
-    }
+    [["ORDER", ORDER], ["COMPACT_ORDER", COMPACT_ORDER],
+     ["PHONE_ORDER", PHONE_ORDER], ["TINY_ORDER", TINY_ORDER]
+    ].forEach(function (pair) {
+      if (pair[1].indexOf(c.k) < 0 && window.console) {
+        console.warn("column " + c.k + " is not in " + pair[0] + "; printed last");
+      }
+    });
   });
   orderColumns();
 
@@ -800,7 +841,7 @@
   /* Rotating the device changes which order the columns should be in, and a
      table left in the other one is the bug this exists to prevent. */
   var onWidthChange = function () { orderColumns(); draw(); };
-  [compact, narrow].forEach(function (mq) {
+  [compact, narrow, tiny].forEach(function (mq) {
     if (mq.addEventListener) mq.addEventListener("change", onWidthChange);
     else if (mq.addListener) mq.addListener(onWidthChange);
   });

--- a/templates/index.html
+++ b/templates/index.html
@@ -184,11 +184,18 @@
     <div>
       <h3>Nitrox and tips</h3>
       <p>
-        Nitrox says <b>included</b>, a price, or <b>extra, no price</b> &mdash;
-        roughly half this fleet bundles it and half bills for it. Crew tips are
-        counted wherever an operator publishes a figure; where one is expected
-        but no amount is given the total reads <b>+ tips</b>, because that cost
-        is real and sits outside the arithmetic.
+        Two thirds of this fleet bundles nitrox and a third bills for it:
+        <b>44</b> vessels say <b>included</b>, <b>21</b> publish a price
+        &mdash; &euro;30 to &euro;100, most often around &euro;77 a week
+        &mdash; and <b>2</b> never mention it at all. Those two read
+        <b>not listed</b>, which is the one thing on this page nitrox can say
+        that is neither yes nor a number: nobody has said whether you will be
+        charged.
+      </p>
+      <p>
+        Crew tips are counted wherever an operator publishes a figure; where
+        one is expected but no amount is given the total reads <b>+ tips</b>,
+        because that cost is real and sits outside the arithmetic.
       </p>
     </div>
     <div>

--- a/templates/style.css
+++ b/templates/style.css
@@ -493,7 +493,12 @@ a { color:var(--accent); }
   :root { --st0:24px; --st1:66px; --st2:96px; }
 
   td.expander, th.expander { padding:4px 6px; }
-  tbody td, thead th { padding:6px 7px; }
+  /* 6px, not 7. Guests moved in front of the money here to sit with the boat,
+     and its 49px put the Total's right edge 4px past a 390px screen -- which
+     clipped the "+ tips" that says the total is not the whole bill. Two pixels
+     a side on the one unpinned column ahead of the price, and two off the
+     price column's own padding, is the whole difference. */
+  tbody td, thead th { padding:6px 5px; }
   /* One line each, ellipsised, on this screen only. Both columns sit behind
      the horizontal scroll here, yet their wrapping still set the height of
      every row: rows ran 35 to 88px and the tallest of them pushed six rows of
@@ -508,8 +513,8 @@ a { color:var(--accent); }
   /* "DEPART ▲" needs 74px of the 66 the pinned date column has here, and a
      header that reads "DEPAR…" is worse than a slightly smaller one. */
   thead th { font-size:9px; letter-spacing:.04em; }
-  /* Cell padding is 7px here, not 9, and the bar has to end where the number
+  /* Cell padding is 5px here, not 9, and the bar has to end where the number
      above it ends. */
-  .anchor { right:7px; }
+  .anchor { right:5px; }
   .site-footer { max-height:60vh; }
 }

--- a/templates/style.css
+++ b/templates/style.css
@@ -490,7 +490,24 @@ a { color:var(--accent); }
      would leave a row that scrolls away from either its dates or its boat. At
      66 + 66 + 96 they take 228px of 390 and True cost, the next column, lands
      inside the remaining 162. */
-  :root { --st0:24px; --st1:66px; --st2:96px; }
+  /* Three here, not two: Depart, Boat and Guests. Guests joined the identity
+     columns in the order, and a group is only a group if the rule that closes
+     it falls after the last of them -- left pinned at two, the strong edge
+     landed between Boat and Guests and filed the guest count with the money,
+     which is the same mistake the wide table made before Guests was pinned
+     there. 24 + 66 + 96 + 45 is 231 of 390, and the Total still lands whole
+     inside what is left. Below 386px Guests is not in front of the money at
+     all, so the count drops back to two -- see `pinned()`. */
+  :root { --st0:24px; --st1:66px; --st2:96px; --st3:45px; }
+
+  /* The group rules, by what the columns mean rather than by where they sit.
+     On a wide screen the light rule falls on `.stick3`, because the pinned
+     four are Depart, Return, Boat, Guests and Boat is third. Here the pinned
+     three are Depart, Boat, Guests, so Boat is second and Guests is third:
+     the light rule moves to `.stick2` and must come off `.stick3`, or it
+     would split the boat from its own guest count. */
+  .stick2 { border-left:1px solid var(--rule); }
+  .stick3 { border-left:0; }
 
   td.expander, th.expander { padding:4px 6px; }
   /* 6px, not 7. Guests moved in front of the money here to sit with the boat,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -506,3 +506,93 @@ class TestTheSourceLinkFollowsTheDeparture(unittest.TestCase):
                 f"{departure['id']} departs {departure['start']} and links to {url}",
             )
         self.assertTrue(checked, "no booking_url carried a month to check")
+
+
+class TestTheFooterCountsMatchTheData(unittest.TestCase):
+    """Numbers written into the page's prose, checked against the dataset.
+
+    The footer said nitrox was "roughly half" included. It is two thirds --
+    44 vessels against 21 -- and the sentence had simply been true once, before
+    the fee scrape covered the whole fleet. It also advertised a state the
+    column has never once rendered, "extra, no price", while omitting the one
+    it does: "not listed", which is the case where nobody has said whether you
+    will be charged at all.
+
+    That is the failure this project exists to correct in other people, in our
+    own words: a page confidently stating a figure that stopped being true. So
+    the prose is now asserted rather than proof-read, the way `promote --check`
+    asserts the dataset and `ALLOWED_EXTERNAL` asserts the page fetches nothing.
+    """
+
+    LIVE = ROOT / "data" / "egypt-2027.json"
+    TEMPLATE = ROOT / "templates" / "index.html"
+
+    def nitrox_by_vessel(self) -> dict[str, int]:
+        """How many *boats* fall in each state. Nitrox is a vessel's policy."""
+        payload = build_payload(Dataset.load(self.LIVE))
+        state: dict[str, str] = {}
+        for departure in payload["departures"]:
+            itinerary = payload["itineraries"][departure["itinerary_id"]]
+            lines = [departure["base_line"]] + (
+                departure.get("lines") or itinerary["lines"]
+            )
+            line = next((x for x in lines if x.get("code") == "nitrox"), None)
+            state[itinerary["boat"]] = (
+                "absent" if line is None
+                else "included" if line.get("included")
+                else "priced" if line.get("has_price")
+                else "listed_unpriced"
+            )
+        counts: dict[str, int] = {}
+        for value in state.values():
+            counts[value] = counts.get(value, 0) + 1
+        return counts
+
+    def test_the_stated_vessel_counts_are_the_real_ones(self):
+        if not self.LIVE.exists():
+            self.skipTest("no scraped dataset in this checkout")
+        counts = self.nitrox_by_vessel()
+        html = self.TEMPLATE.read_text(encoding="utf-8")
+        for number, state in (
+            (counts.get("included", 0), "included"),
+            (counts.get("priced", 0), "publish a price"),
+            (counts.get("absent", 0), "never mention it"),
+        ):
+            # assertTrue rather than assertIn: the failure message for a
+            # missing substring prints the whole haystack, and the haystack
+            # here is the entire page.
+            self.assertTrue(
+                f"<b>{number}</b>" in html,
+                f"the footer does not say <b>{number}</b> vessels for "
+                f"{state!r}; the committed dataset says it should",
+            )
+
+    def test_the_footer_names_only_states_the_column_can_reach(self):
+        """It advertised "extra, no price", which no vessel has ever produced.
+
+        Naming a state nobody will see is a smaller sin than the reverse and
+        still a claim about the data that the data does not support.
+        """
+        if not self.LIVE.exists():
+            self.skipTest("no scraped dataset in this checkout")
+        html = self.TEMPLATE.read_text(encoding="utf-8")
+        if not self.nitrox_by_vessel().get("listed_unpriced"):
+            self.assertTrue(
+                "extra, no price" not in html,
+                "the footer offers 'extra, no price' as a nitrox state, and no "
+                "vessel in the dataset produces it",
+            )
+
+    def test_the_unreachable_branch_is_still_in_the_renderer(self):
+        """Unreached is not unnecessary.
+
+        No vessel lists nitrox without a price today, but "Rental Gear" is
+        routinely named with no figure, so the shape is real. Without the
+        branch the function falls off the end and the cell prints "undefined".
+        """
+        app = (ROOT / "templates" / "app.js").read_text(encoding="utf-8")
+        self.assertTrue(
+            "extra, no price" in app,
+            "app.js has lost the fallback branch; a nitrox line that is "
+            "neither included nor priced would render as 'undefined'",
+        )


### PR DESCRIPTION
Three changes: the phone table now follows the same column rules and the same
grouping as the wide one, and the footer's nitrox paragraph is corrected and
put under test.

## The phone was following three of the four column rules

Guests sat among From, To and Trip — the section it was explicitly moved out
of — and the price block ran in an order belonging to no other width.

```
before   Depart | Boat | Total | Mandatory fees | Advertised | Nitrox …
after    Depart | Boat | Pax   | Total | Advertised | Nitrox | Mandatory fees …
```

**The bill order cannot lead on a phone**, and this is measured rather than
preferred. At 390px, putting Advertised, Nitrox and Mandatory fees ahead of the
Total lands the Total's left edge at **x=1247**; even with nothing but the
pinned columns before them it is x=477. The one number the page exists to
publish would be off the edge on the device most people open it on. So the
Total leads and its parts follow it *in bill order* — scrolling right reads the
bill, not scrolling still answers the question.

## The grouping said Guests belonged to the money

The order put Guests next to the Boat; the rule that closes the pinned group
still fell between them, undoing on a phone exactly what pinning a fourth
column fixed on a wide screen.

```
wide    Depart | Return | Boat : Guests ║ money
phone            Depart | Boat : Pax    ║ money
```

A phone pins three now. The light rule inside the group moves from `.stick3` to
`.stick2`, because the pinned three here are Depart, Boat, Guests rather than
the wide four — Boat is second, not third, and left alone that rule would have
split the boat from its own guest count.

A pinned column is a fixed width and `GUESTS` wants 65px of the 45 it has, so
headers can now carry a short form for narrow screens — **`Pax`**, with the
full word as the tooltip, returning to `Guests` on resize. Same call the date
column already made when it took a smaller font rather than print `DEPAR…`.
Sorting is keyed on `data-k` and is unaffected.

## A regression caught by measuring, not by looking

Guests in front of the price puts the Total's right edge at 386 — fine at
390px, **26px past the edge of a 360px screen**, which is a Galaxy S-series and
most older Androids. Silent, too: the row still renders, it just stops
answering. So there is a fourth breakpoint at 385px where Guests moves back
behind the money, and `tiny` joins `compact` and `narrow` on the resize
listener or rotating a small phone would strand the wrong order.

Narrow cell padding goes 7px → 5px, which buys the Total its last four pixels
at 390 and stops `+ tips` being clipped. `.anchor` follows it, or the bar would
stop ending where the number above it does.

The startup check now tests **all four** order lists rather than only the
widest: a column missing from one list is a fact the page stops publishing at
that width alone, which is the hardest kind of gap to notice.

## Nitrox: the footer was wrong in three ways

It said "roughly half" this fleet includes nitrox and offered *included*, *a
price*, or *extra, no price*. Measured against the committed dataset:

| | vessels | |
|---|---|---|
| included | **44** | 66%, not "half" |
| publish a price | **21** | €30–€100, median €77 |
| never mention it | **2** | Sea Friend, New Sambo — renders `not listed` |
| listed with no price | **0** | the state the footer advertised |

So it named a state that has never rendered and omitted the one that does —
and `not listed` is precisely the case where nobody has said whether you will
be charged. The sentence had been true once, before the fee scrape reached the
whole fleet, and nothing noticed when it stopped being.

**The prose is now asserted rather than proof-read**, the way `promote --check`
asserts the dataset: three tests read the committed dataset, count the vessels
in each state, and fail if the numbers or the named states drift. Each was
verified by breaking it and watching it fail.

The unreachable fourth branch stays in `app.js`, now documented as unreached
rather than looking like an oversight — without it the function falls off the
end and the cell prints `undefined`, and the shape is real, since "Rental Gear"
is routinely listed with no figure.

## Verification

- **421 tests**, up from 418
- `promote --check` clean; no dataset numbers change, only what the page says
- 320, 360, 375, 385, 386, 390, 412, 430, 600, 760, 761, 1000, 1440, 1700,
  1701, 1920 and 2560px in **both colour schemes** — 34 combinations — each
  opening its bill: no console output, no horizontal overflow, Total on screen
- Breakpoint flips exactly at 386 as the measurement predicts; live resize
  reorders and relabels in both directions
- Guests column sorts 8 → 36 ascending and 36 → 8 descending through the
  renamed header

## Not fixed, pre-existing on main

- **761–800px** clips the Total at 775 — the compact order's three prices ahead
  of it. Unrelated to these lists.
- **320px** cannot fit it either, on `main` too.
- At **760–1700px** Guests is not grouped with the Boat at all; the compact
  order puts it after Per dive. So the rule now holds at ≥1701px and ≤760px but
  not between. Left alone rather than folded in here, since fixing it moves the
  Total's right edge from 775 to ~837 and pairs naturally with the tablet
  clipping above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK


---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_