### PR TITLE
Drop the average mandatory fees from the masthead

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -561,7 +561,6 @@ a { color:var(--accent); }
     <div class="stat"><b id="shown">0</b><span>rows shown</span></div>
     <div class="stat"><b id="nboats">0</b><span>boats</span></div>
     <div class="stat"><b id="nitin">0</b><span>itineraries</span></div>
-    <div class="stat"><b id="gap">&mdash;</b><span>avg mandatory fees</span></div>
   </div>
 </div>
 
@@ -722,8 +721,8 @@ a { color:var(--accent); }
       <h3>Nitrox and tips</h3>
       <p>
         Two thirds of this fleet bundles nitrox and a third bills for it:
-        <b>44</b> vessels say <b>included</b>, <b>21</b> publish a price
-        &mdash; &euro;30 to &euro;100, most often around &euro;77 a week
+        <b>42</b> vessels say <b>included</b>, <b>21</b> publish a price
+        &mdash; &euro;30 to &euro;100, most often around &euro;70 a week
         &mdash; and <b>2</b> never mention it at all. Those two read
         <b>not listed</b>, which is the one thing on this page nitrox can say
         that is neither yes nor a number: nobody has said whether you will be
@@ -1484,14 +1483,6 @@ a { color:var(--accent); }
     rows.forEach(function (r) { boats[r.i.boat_id] = 1; itins[r.i.id] = 1; });
     document.getElementById("nboats").textContent = Object.keys(boats).length;
     document.getElementById("nitin").textContent = Object.keys(itins).length;
-
-    /* Only average what has a figure: a trip whose required extras are
-       unstated has no gap to average, and counting it as zero would drag the
-       number toward "no fees on top". */
-    var known = rows.filter(function (r) { return r.d.mandatory_known; });
-    document.getElementById("gap").textContent = known.length
-      ? eur(known.reduce(function (s, r) { return s + r.m.later; }, 0) / known.length)
-      : "—";
   }
 
   /* How many chips a bank shows before the rest go behind "more".

--- a/templates/app.js
+++ b/templates/app.js
@@ -667,14 +667,6 @@
     rows.forEach(function (r) { boats[r.i.boat_id] = 1; itins[r.i.id] = 1; });
     document.getElementById("nboats").textContent = Object.keys(boats).length;
     document.getElementById("nitin").textContent = Object.keys(itins).length;
-
-    /* Only average what has a figure: a trip whose required extras are
-       unstated has no gap to average, and counting it as zero would drag the
-       number toward "no fees on top". */
-    var known = rows.filter(function (r) { return r.d.mandatory_known; });
-    document.getElementById("gap").textContent = known.length
-      ? eur(known.reduce(function (s, r) { return s + r.m.later; }, 0) / known.length)
-      : "—";
   }
 
   /* How many chips a bank shows before the rest go behind "more".

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,6 @@
     <div class="stat"><b id="shown">0</b><span>rows shown</span></div>
     <div class="stat"><b id="nboats">0</b><span>boats</span></div>
     <div class="stat"><b id="nitin">0</b><span>itineraries</span></div>
-    <div class="stat"><b id="gap">&mdash;</b><span>avg mandatory fees</span></div>
   </div>
 </div>
 
@@ -185,8 +184,8 @@
       <h3>Nitrox and tips</h3>
       <p>
         Two thirds of this fleet bundles nitrox and a third bills for it:
-        <b>44</b> vessels say <b>included</b>, <b>21</b> publish a price
-        &mdash; &euro;30 to &euro;100, most often around &euro;77 a week
+        <b>42</b> vessels say <b>included</b>, <b>21</b> publish a price
+        &mdash; &euro;30 to &euro;100, most often around &euro;70 a week
         &mdash; and <b>2</b> never mention it at all. Those two read
         <b>not listed</b>, which is the one thing on this page nitrox can say
         that is neither yes nor a number: nobody has said whether you will be


### PR DESCRIPTION
Removed on request. The masthead keeps three stats — rows shown, boats,
itineraries — which describe what is on screen. The average described the
fleet, and an average of the very thing the table shows row by row adds
nothing a visitor can act on.

The `<div class="stat">` goes, and so does the block in `draw()` that fed it,
so nothing computes a number nobody reads. `eur()` and `mandatory_known` both
stay — five other callers between them.

## It also caught the nitrox footer drifting, in a day

The tests added in #68 to stop the footer's numbers going stale failed on the
first build after the overnight refresh:

```
AssertionError: the footer does not say <b>42</b> vessels for 'included';
the committed dataset says it should
```

The refresh dropped two vessels from the fleet — 67 to 65 — so **44 boats
including nitrox is now 42**, and the median stated price fell from **€77 to
€70**. Both corrected here.

That is the guard working as intended. The sentence it replaced ("roughly
half") had been wrong for months with nothing objecting; this one lasted a day.

One thing worth recording, since it nearly became a wrong edit: the naive query
for "cheapest stated nitrox price" returns **€0**, because five vessels carry a
priced nitrox line *and* `included: true`. The renderer tests `included` first,
so those correctly show *included* and never reach the price — the €0 is real
in the data and unreachable on the page. Recomputing with the renderer's own
precedence gives the true range, €30 to €100.

## Verification

- 421 tests, `promote --check` clean
- Rendered at 390px and 1440px: masthead shows three stats, all three still
  update on filtering (838 → 18 rows, 65 → 1 boat, 308 → 9 itineraries), no
  console output
- No orphaned references to `#gap` anywhere in `templates/`, `src/` or `tests/`

Note the counts in this PR's build — 838 departures, 308 itineraries, 65 boats
against yesterday's 881/315/67 — are the daily refresh already on `main`, not
anything in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK


---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_