### PR TITLE
Let a visitor mark a row, to keep their place across sixteen columns

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -21,6 +21,19 @@
   --later:#a8500f; --later-soft:#fbeee2;
   --ok:#1f6b45; --warn:#8a6410; --unknown:#6c7481; --sold:#9c3535;
   --row-alt:#fbfcfd; --row-hover:#eef4f9;
+  /* A marked row, painted on the pinned identity columns only -- never across
+     the whole row, and that is a contrast result rather than a style choice.
+     Tinting the full row puts a colour behind the Places and Disclosure pills,
+     and those are the two weakest colours in this palette: --unknown is 4.72:1
+     on plain white, so *any* tint at all drops it under AA. There is no fill
+     light enough to be visible and still safe -- at #f4f9fd, nearly white, it
+     is still 4.45.
+     The pinned cells carry dates, the boat and the guest count in --ink at
+     14:1, so a much stronger tint is safe there, and they are the columns that
+     stay on screen at every scroll position anyway. Which is the whole point:
+     the mark has to be legible when you have scrolled 900px right to read
+     Mandatory fees. */
+  --row-marked:#dbe9f5; --row-marked-edge:var(--accent);
 
   /* The pinned columns, left to right, and therefore each one's offset from
      the one before. Fixed widths rather than floors: content wider than a
@@ -73,6 +86,7 @@
     --later:#e8a86a; --later-soft:#2e2015;
     --ok:#6cc394; --warn:#d6ad55; --unknown:#7d8798; --sold:#e08379;
     --row-alt:#111820; --row-hover:#1b2531;
+    --row-marked:#203446; --row-marked-edge:var(--accent);
   }
 }
 :root[data-theme="dark"] {
@@ -82,6 +96,7 @@
   --later:#e8a86a; --later-soft:#2e2015;
   --ok:#6cc394; --warn:#d6ad55; --unknown:#7d8798; --sold:#e08379;
   --row-alt:#111820; --row-hover:#1b2531;
+  --row-marked:#203446; --row-marked-edge:var(--accent);
 }
 
 * { box-sizing: border-box; }
@@ -241,6 +256,17 @@ tbody td.cost { position:relative; }
 tbody tr.row.alt { background:var(--row-alt); }
 tbody tr.row:hover { background:var(--row-hover); }
 
+/* A row the visitor has marked, to keep their place.
+ *
+ * The table is 2400px wide on a desktop and the window is not, so reading
+ * Mandatory fees means scrolling until the boat's name is gone. Hover tracks
+ * the pointer and nothing else, which is no help the moment the pointer moves
+ * to the scrollbar -- so the number and the row it belongs to are separated by
+ * a screen's width and nothing joins them. This does.
+ *
+ * The paint is on the pinned columns, below, not here: see --row-marked for
+ * why a full-row tint cannot be made accessible. */
+
 .num {
   font-family:var(--font-mono);
   font-variant-numeric:tabular-nums;
@@ -281,6 +307,16 @@ tbody tr.row.alt .stick1, tbody tr.row.alt .stick2,
 tbody tr.row.alt .stick3, tbody tr.row.alt .stick4 { background:var(--row-alt); }
 tbody tr.row:hover .stick1, tbody tr.row:hover .stick2,
 tbody tr.row:hover .stick3, tbody tr.row:hover .stick4 { background:var(--row-hover); }
+/* Where a mark is actually drawn. The pinned cells already paint their own
+   background -- they have to, or the columns sliding beneath would show
+   through -- so this is both the safe place to tint and the one that stays
+   on screen however far right the table is scrolled. */
+tbody tr.row.marked .stick1, tbody tr.row.marked .stick2,
+tbody tr.row.marked .stick3, tbody tr.row.marked .stick4,
+tbody tr.row.marked:hover .stick1, tbody tr.row.marked:hover .stick2,
+tbody tr.row.marked:hover .stick3, tbody tr.row.marked:hover .stick4 {
+  background:var(--row-marked);
+}
 thead th.stick1, thead th.stick2, thead th.stick3, thead th.stick4 { z-index:25; }
 
 /* The control that opens the bill, at the start of the row and pinned with the
@@ -302,6 +338,15 @@ td.expander, th.expander {
 thead th.expander { z-index:25; }
 tbody tr.row.alt .expander { background:var(--row-alt); }
 tbody tr.row:hover .expander { background:var(--row-hover); }
+/* The mark itself: a bar down the pinned first cell, which is the one column
+   that is on screen at every scroll position and every width. Drawn with an
+   inset shadow rather than a border so it costs the row no height and shifts
+   no column by a pixel -- the same reason the anchor bar is positioned rather
+   than laid out. */
+tbody tr.row.marked .expander, tbody tr.row.marked:hover .expander {
+  background:var(--row-marked);
+  box-shadow:inset 3px 0 0 0 var(--row-marked-edge);
+}
 
 /* And the bill itself stays put while the table scrolls under it. The detail
    cell spans the full 2446px, so its contents would otherwise sit wherever the
@@ -554,7 +599,8 @@ a { color:var(--accent); }
       the <strong>total</strong> &mdash; the advertised berth plus marine park
       fees, port dues, fuel and everything else that lands on the bill later.
       Sort any column; expand a row for the whole bill and where each number
-      came from.
+      came from; click a row to mark it, so you can still tell which is which
+      once you have scrolled sideways.
     </p>
   </div>
   <div class="stats">
@@ -840,7 +886,12 @@ a { color:var(--accent); }
     sort: "start", dir: 1, q: "",
     months: new Set(), ports: new Set(), sites: new Set(), boats: new Set(),
     nightsMin: null, nightsMax: null, hideSoldOut: false,
-    toggles: {}, open: null
+    toggles: {}, open: null,
+    /* Rows the visitor has marked to keep their place while scrolling
+       sideways. Keyed on the departure id rather than the row index, so a
+       mark survives sorting, filtering and the table being redrawn under it --
+       an index would follow the position and mark whatever moved into it. */
+    marked: new Set()
   };
   D.facets.toggles.forEach(function (t) { state.toggles[t.id] = t.default; });
 
@@ -1467,8 +1518,10 @@ a { color:var(--accent); }
              `:nth-of-type(even)`. That selector counts every `tr` in the
              tbody, and an expanded row injects one -- so opening any row
              inverted the stripes of every row below it. */
+          var marked = state.marked.has(row.d.id);
           return '<tr class="row' + (n % 2 ? " alt" : "") +
-            (row.d.bookable ? "" : " gone") + '">' +
+            (row.d.bookable ? "" : " gone") + (marked ? " marked" : "") +
+            '" aria-selected="' + marked + '" data-id="' + esc(row.d.id) + '">' +
             '<td class="expander"><button class="expand" data-n="' + n +
             '" aria-expanded="' + open + '">' + (open ? "−" : "+") + "</button></td>" +
             tds + "</tr>" +
@@ -1587,9 +1640,36 @@ a { color:var(--accent); }
 
   document.getElementById("body").addEventListener("click", function (event) {
     var button = event.target.closest(".expand");
-    if (!button) return;
-    var row = visible()[+button.dataset.n];
-    state.open = state.open === row.d.id ? null : row.d.id;
+    if (button) {
+      var row = visible()[+button.dataset.n];
+      state.open = state.open === row.d.id ? null : row.d.id;
+      draw();
+      return;
+    }
+
+    /* Anywhere else on a row marks it, so the visitor can keep their place
+       while scrolling sixteen columns sideways.
+     *
+       Three things it must not do. It must not steal a click meant for a
+       link -- the Source column opens the operator's own listing, and a
+       marked row is no consolation for not going there. It must not fire
+       inside an expanded bill, which is a panel the visitor opened and not
+       part of the row's own surface. And it must not fire at the end of a
+       drag: selecting a price to copy it ends in a mouseup over the row, and
+       toggling a highlight underneath the text being selected reads as the
+       page fighting back. `isCollapsed` is false exactly when text was
+       dragged, which is the distinction wanted -- not whether a selection
+       exists, since an old one elsewhere on the page would then block every
+       mark. */
+    if (event.target.closest("a, button")) return;
+    var tr = event.target.closest("tr.row");
+    if (!tr) return;
+    var selection = window.getSelection && window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+
+    var id = tr.dataset.id;
+    if (state.marked.has(id)) state.marked.delete(id);
+    else state.marked.add(id);
     draw();
   });
 
@@ -1651,6 +1731,10 @@ a { color:var(--accent); }
   document.getElementById("reset").addEventListener("click", function () {
     state.months.clear(); state.ports.clear(); state.sites.clear();
     state.boats.clear();
+    /* Marks go with the filters. Reset puts the table back to how it opened,
+       and a highlight left behind on a row the visitor can no longer find is
+       worse than no highlight at all. */
+    state.marked.clear();
     state.q = "";
     state.nightsMin = state.nightsMax = null;
     state.hideSoldOut = false;

--- a/templates/app.js
+++ b/templates/app.js
@@ -24,7 +24,12 @@
     sort: "start", dir: 1, q: "",
     months: new Set(), ports: new Set(), sites: new Set(), boats: new Set(),
     nightsMin: null, nightsMax: null, hideSoldOut: false,
-    toggles: {}, open: null
+    toggles: {}, open: null,
+    /* Rows the visitor has marked to keep their place while scrolling
+       sideways. Keyed on the departure id rather than the row index, so a
+       mark survives sorting, filtering and the table being redrawn under it --
+       an index would follow the position and mark whatever moved into it. */
+    marked: new Set()
   };
   D.facets.toggles.forEach(function (t) { state.toggles[t.id] = t.default; });
 
@@ -651,8 +656,10 @@
              `:nth-of-type(even)`. That selector counts every `tr` in the
              tbody, and an expanded row injects one -- so opening any row
              inverted the stripes of every row below it. */
+          var marked = state.marked.has(row.d.id);
           return '<tr class="row' + (n % 2 ? " alt" : "") +
-            (row.d.bookable ? "" : " gone") + '">' +
+            (row.d.bookable ? "" : " gone") + (marked ? " marked" : "") +
+            '" aria-selected="' + marked + '" data-id="' + esc(row.d.id) + '">' +
             '<td class="expander"><button class="expand" data-n="' + n +
             '" aria-expanded="' + open + '">' + (open ? "−" : "+") + "</button></td>" +
             tds + "</tr>" +
@@ -771,9 +778,36 @@
 
   document.getElementById("body").addEventListener("click", function (event) {
     var button = event.target.closest(".expand");
-    if (!button) return;
-    var row = visible()[+button.dataset.n];
-    state.open = state.open === row.d.id ? null : row.d.id;
+    if (button) {
+      var row = visible()[+button.dataset.n];
+      state.open = state.open === row.d.id ? null : row.d.id;
+      draw();
+      return;
+    }
+
+    /* Anywhere else on a row marks it, so the visitor can keep their place
+       while scrolling sixteen columns sideways.
+     *
+       Three things it must not do. It must not steal a click meant for a
+       link -- the Source column opens the operator's own listing, and a
+       marked row is no consolation for not going there. It must not fire
+       inside an expanded bill, which is a panel the visitor opened and not
+       part of the row's own surface. And it must not fire at the end of a
+       drag: selecting a price to copy it ends in a mouseup over the row, and
+       toggling a highlight underneath the text being selected reads as the
+       page fighting back. `isCollapsed` is false exactly when text was
+       dragged, which is the distinction wanted -- not whether a selection
+       exists, since an old one elsewhere on the page would then block every
+       mark. */
+    if (event.target.closest("a, button")) return;
+    var tr = event.target.closest("tr.row");
+    if (!tr) return;
+    var selection = window.getSelection && window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+
+    var id = tr.dataset.id;
+    if (state.marked.has(id)) state.marked.delete(id);
+    else state.marked.add(id);
     draw();
   });
 
@@ -835,6 +869,10 @@
   document.getElementById("reset").addEventListener("click", function () {
     state.months.clear(); state.ports.clear(); state.sites.clear();
     state.boats.clear();
+    /* Marks go with the filters. Reset puts the table back to how it opened,
+       and a highlight left behind on a row the visitor can no longer find is
+       worse than no highlight at all. */
+    state.marked.clear();
     state.q = "";
     state.nightsMin = state.nightsMax = null;
     state.hideSoldOut = false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,8 @@
       the <strong>total</strong> &mdash; the advertised berth plus marine park
       fees, port dues, fuel and everything else that lands on the bill later.
       Sort any column; expand a row for the whole bill and where each number
-      came from.
+      came from; click a row to mark it, so you can still tell which is which
+      once you have scrolled sideways.
     </p>
   </div>
   <div class="stats">

--- a/templates/style.css
+++ b/templates/style.css
@@ -14,6 +14,19 @@
   --later:#a8500f; --later-soft:#fbeee2;
   --ok:#1f6b45; --warn:#8a6410; --unknown:#6c7481; --sold:#9c3535;
   --row-alt:#fbfcfd; --row-hover:#eef4f9;
+  /* A marked row, painted on the pinned identity columns only -- never across
+     the whole row, and that is a contrast result rather than a style choice.
+     Tinting the full row puts a colour behind the Places and Disclosure pills,
+     and those are the two weakest colours in this palette: --unknown is 4.72:1
+     on plain white, so *any* tint at all drops it under AA. There is no fill
+     light enough to be visible and still safe -- at #f4f9fd, nearly white, it
+     is still 4.45.
+     The pinned cells carry dates, the boat and the guest count in --ink at
+     14:1, so a much stronger tint is safe there, and they are the columns that
+     stay on screen at every scroll position anyway. Which is the whole point:
+     the mark has to be legible when you have scrolled 900px right to read
+     Mandatory fees. */
+  --row-marked:#dbe9f5; --row-marked-edge:var(--accent);
 
   /* The pinned columns, left to right, and therefore each one's offset from
      the one before. Fixed widths rather than floors: content wider than a
@@ -66,6 +79,7 @@
     --later:#e8a86a; --later-soft:#2e2015;
     --ok:#6cc394; --warn:#d6ad55; --unknown:#7d8798; --sold:#e08379;
     --row-alt:#111820; --row-hover:#1b2531;
+    --row-marked:#203446; --row-marked-edge:var(--accent);
   }
 }
 :root[data-theme="dark"] {
@@ -75,6 +89,7 @@
   --later:#e8a86a; --later-soft:#2e2015;
   --ok:#6cc394; --warn:#d6ad55; --unknown:#7d8798; --sold:#e08379;
   --row-alt:#111820; --row-hover:#1b2531;
+  --row-marked:#203446; --row-marked-edge:var(--accent);
 }
 
 * { box-sizing: border-box; }
@@ -234,6 +249,17 @@ tbody td.cost { position:relative; }
 tbody tr.row.alt { background:var(--row-alt); }
 tbody tr.row:hover { background:var(--row-hover); }
 
+/* A row the visitor has marked, to keep their place.
+ *
+ * The table is 2400px wide on a desktop and the window is not, so reading
+ * Mandatory fees means scrolling until the boat's name is gone. Hover tracks
+ * the pointer and nothing else, which is no help the moment the pointer moves
+ * to the scrollbar -- so the number and the row it belongs to are separated by
+ * a screen's width and nothing joins them. This does.
+ *
+ * The paint is on the pinned columns, below, not here: see --row-marked for
+ * why a full-row tint cannot be made accessible. */
+
 .num {
   font-family:var(--font-mono);
   font-variant-numeric:tabular-nums;
@@ -274,6 +300,16 @@ tbody tr.row.alt .stick1, tbody tr.row.alt .stick2,
 tbody tr.row.alt .stick3, tbody tr.row.alt .stick4 { background:var(--row-alt); }
 tbody tr.row:hover .stick1, tbody tr.row:hover .stick2,
 tbody tr.row:hover .stick3, tbody tr.row:hover .stick4 { background:var(--row-hover); }
+/* Where a mark is actually drawn. The pinned cells already paint their own
+   background -- they have to, or the columns sliding beneath would show
+   through -- so this is both the safe place to tint and the one that stays
+   on screen however far right the table is scrolled. */
+tbody tr.row.marked .stick1, tbody tr.row.marked .stick2,
+tbody tr.row.marked .stick3, tbody tr.row.marked .stick4,
+tbody tr.row.marked:hover .stick1, tbody tr.row.marked:hover .stick2,
+tbody tr.row.marked:hover .stick3, tbody tr.row.marked:hover .stick4 {
+  background:var(--row-marked);
+}
 thead th.stick1, thead th.stick2, thead th.stick3, thead th.stick4 { z-index:25; }
 
 /* The control that opens the bill, at the start of the row and pinned with the
@@ -295,6 +331,15 @@ td.expander, th.expander {
 thead th.expander { z-index:25; }
 tbody tr.row.alt .expander { background:var(--row-alt); }
 tbody tr.row:hover .expander { background:var(--row-hover); }
+/* The mark itself: a bar down the pinned first cell, which is the one column
+   that is on screen at every scroll position and every width. Drawn with an
+   inset shadow rather than a border so it costs the row no height and shifts
+   no column by a pixel -- the same reason the anchor bar is positioned rather
+   than laid out. */
+tbody tr.row.marked .expander, tbody tr.row.marked:hover .expander {
+  background:var(--row-marked);
+  box-shadow:inset 3px 0 0 0 var(--row-marked-edge);
+}
 
 /* And the bill itself stays put while the table scrolls under it. The detail
    cell spans the full 2446px, so its contents would otherwise sit wherever the


### PR DESCRIPTION
The table is about 2400px wide and the window is not, so reading Mandatory
fees means scrolling until the boat's name has gone. Hover follows the pointer
and nothing else, which stops helping the moment the pointer moves to the
scrollbar. Clicking a row now marks it.

The mark survives scrolling, sorting, filtering and redrawing; several rows can
be marked at once, which is the point on a page for comparing boats; and Reset
clears them along with the filters.

Keyed on the **departure id, not the row index**. An index follows the
position, so a sort would leave the mark on whatever moved into that slot —
worse than losing it, because it still looks right.

## The tint is on the pinned columns, and that is a contrast result

I tinted the whole row first, then measured. It is unshippable: `--unknown`,
the Disclosure "not stated" pill, is **4.72:1 on plain white**, so *any* row
tint drops it under AA. There is no fill light enough to be visible and still
safe — at `#f4f9fd`, nearly white, it is still 4.45.

| | on a plain row | on a full-row tint |
|---|---|---|
| `--unknown` (Disclosure) | 4.72 | **3.90** |
| `--warn` (Places, "a few left") | 5.37 | **4.44** |
| `--later` (Mandatory fees) | — | **4.45** |

So the tint went onto the pinned identity columns only. They carry dates, boat
and guests in `--ink` at 14:1, and they are the columns that stay on screen
however far right the table has scrolled — which is exactly the situation the
mark exists for. Every foreground colour in both schemes now clears AA, worst
case 4.72, and the pills keep their plain-row background untouched.

The edge bar is an inset shadow rather than a border, so it costs the row no
height and shifts no column by a pixel — the same reason the anchor bar is
positioned rather than laid out.

## Three things a row click must not do

All covered, all tested:

```
4. expander still expands, does NOT mark   detail rows=1, marks 1->1
5. click inside the expanded bill          marks 1->1
6. drag-select text in a cell              selected 'Blue Melody', marks 1->1
```

The drag case matters: selecting a price to copy ends in a mouseup over the
row, and toggling a highlight under the text being selected reads as the page
fighting back. The guard is `!selection.isCollapsed` — true exactly when text
was *dragged* — rather than "is anything selected", which an old selection
elsewhere on the page would make permanently true.

## Verification

- 10-point interaction suite: mark, multi-mark, toggle off, expander unaffected,
  bill click inert, drag-select inert, survives sort, survives filter, Reset
  clears, Source link still navigates
- Contrast computed for every foreground colour in both schemes
- 360, 390 and 1440px, light and dark: no console output, no overflow
- 421 tests, `promote --check` clean; no dataset change

## Judgement calls

- **Not gated to desktop**, though that is where it was asked for. The table
  scrolls sideways on a phone too and a horizontal drag there is a scroll, not
  a click, so nothing competes for the gesture.
- **Rows are not tab stops.** They carry `aria-selected` so the state is
  exposed, but 838 rows would be 838 tab stops, and a keyboard user already has
  a visible place-marker in the focus ring. This solves a pointer problem.

Discoverability: one clause added to the masthead, which already lists the
table's interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK


---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_