### PR TITLE
Say what moved in the commit subject, and keep the change history in the repo

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -151,14 +151,30 @@ jobs:
 
       # Before the commit, while HEAD is still yesterday's dataset. Afterwards
       # the comparison would be against the run's own output.
+      #
+      # Three destinations, because a run summary is gone once the run ages
+      # out: the summary for whoever opens the run, data/CHANGES.md for the
+      # durable history, and one line captured for the commit subject so
+      # `git log --oneline data/` reads as the changelog it always was.
       - name: Report what changed
+        id: changed
         run: |
           PYTHONPATH=src python3 -m liveaboard.cli changes \
             --data ${{ steps.dataset.outputs.path }} \
             --revision HEAD \
+            --append data/CHANGES.md \
             >> "$GITHUB_STEP_SUMMARY"
+          headline=$(PYTHONPATH=src python3 -m liveaboard.cli changes \
+            --data ${{ steps.dataset.outputs.path }} --revision HEAD --headline)
+          echo "headline=${headline}" >> "$GITHUB_OUTPUT"
 
       - name: Commit changes
+        # Through the environment, not `${{ }}`: the headline carries boat
+        # names that came off somebody else's web page, and interpolating
+        # those straight into a shell line is how a scraped string becomes a
+        # command.
+        env:
+          HEADLINE: ${{ steps.changed.outputs.headline }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -168,8 +184,9 @@ jobs:
             exit 0
           fi
           # Every run is a commit, so the git history doubles as price history:
-          # `git log -p data/` shows exactly which fee moved, and when.
-          git commit -m "data: daily refresh $(date -u +%Y-%m-%d)"
+          # `git log -p data/` shows exactly which fee moved, and when — and
+          # the subject says which, so finding it does not mean opening 2 MB.
+          git commit -m "data: daily refresh $(date -u +%Y-%m-%d) — ${HEADLINE}"
 
           # A scrape takes minutes, and anything can land meanwhile -- the
           # other scheduled job, or a merge. A plain push is rejected and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ price and reassembles the real bill. See README.md for the domain.
 ## Commands
 
 ```bash
-PYTHONPATH=src python3 -m unittest discover -s tests   # 432 tests, no deps
+PYTHONPATH=src python3 -m unittest discover -s tests   # 445 tests, no deps
 PYTHONPATH=src python3 -m liveaboard.cli check         # validate + summarise
 PYTHONPATH=src python3 -m liveaboard.cli build         # -> site/index.html
+PYTHONPATH=src python3 -m liveaboard.cli changes       # what moved since HEAD~1
 python3 tools/make_seed.py                             # regenerate seed data
 ```
 
@@ -103,6 +104,14 @@ Break these and the site starts lying quietly rather than failing loudly.
   slow or unreachable, against 0.6 seconds without it (#59). Fonts are the
   visitor's own now. Adding a host back is adding a way for the page to be
   blank on somebody else's network.
+- **A change report never drops a row silently.** `changes` caps its blocks and
+  suppresses sub-unit price moves as source rounding — and says so, with a
+  count, every time. A truncated list that does not admit it reads as "that was
+  everything", which is exactly the failure this project exists to correct in
+  other people. The same rule kills four false positives it used to report: an
+  FX move is not a reprice, a vessel losing *every* departure is a failed fetch
+  and not a cancelled season, a newly parsed field has not changed, and a
+  currency switch is not a price move.
 - **The committed seed must match `tools/make_seed.py`** — CI enforces it, so
   edit the generator, not the JSON.
 - **The committed dataset must match what `promote` produces from the committed

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ tests/            stdlib unittest, no dependencies
 | `data/fees.json` | fee book **and** the disclosure text each parse was made from | yes |
 | `data/archive.json` | every JSON-LD node each page published, parsed or not | yes |
 | `data/itineraries.json` | what each *trip* says about itself: reefs, dive count, group size, entry bar | yes |
+| `data/CHANGES.md` | what moved on each refresh, newest first | yes |
 | `data/snapshots/` | raw pages | no — gitignored, CI artifact for 14 days |
 
 The dataset is **regenerated, not edited**. `promote` is pure — candidate, fees,
@@ -148,6 +149,34 @@ ones cannot. It carries ratings, cabin counts, occupancy, amenities and
 remaining capacity — none of which the site uses today — so a question asked
 next month can still be put to this month's data. Every run is a commit, so
 `git log -p data/` is the history.
+
+### Noticing that something moved
+
+The history was always there and nobody could read it: five new departures
+show up as `886` where yesterday said `881`, and a two-hundred-dollar rise is
+a two-megabyte JSON diff. `changes` turns two datasets into a few lines —
+which boats and trips appeared, which departures were added or withdrawn,
+which fares moved and by how much, which fees changed, what sold out.
+
+```bash
+PYTHONPATH=src python3 -m liveaboard.cli changes                    # vs HEAD~1
+PYTHONPATH=src python3 -m liveaboard.cli changes --revision HEAD~7  # a week
+PYTHONPATH=src python3 -m liveaboard.cli changes --headline         # one line
+```
+
+The daily refresh writes it to three places, because a workflow run summary
+disappears when the run ages out: the run summary, `data/CHANGES.md`
+(committed, newest first), and the subject of the data commit itself — so
+`git log --oneline data/` reads as the changelog rather than 23 identical
+lines saying `data: daily refresh`.
+
+Four distinctions decide whether it is worth reading, and all four are
+false positives it used to report: a euro figure moving because the ECB moved
+is not an operator repricing; a fare moving by one dollar is the source
+re-rounding (174 of them in one run); a vessel that lost *every* departure at
+once is a failed fetch, not a cancelled season; and a field a parser has just
+learned to read has not changed — the first run after `availability` was
+parsed announced 126 sailings as newly sold out, and nobody had looked before.
 
 ## Next
 

--- a/data/CHANGES.md
+++ b/data/CHANGES.md
@@ -1,0 +1,39 @@
+# What changed
+
+One entry per refresh, newest first, written by `liveaboard.cli changes`.
+Do not edit by hand — the next run rewrites the file around this header.
+
+## 2026-08-28
+
+```
+changes: a32d170 -> 2026-08-28
+==============================
+
+new departures (6)
+  2027-07-24  Oceanix                Brothers, Daedalus, Elphinstone        1,154 USD
+  2027-08-02  Ghazala Adventure      North, Tiran & Dahab                   1,608 USD
+  2027-08-09  Ghazala Adventure      North: Wrecks & Reefs                  1,571 USD
+  2027-08-16  Ghazala Adventure      North: Wrecks & Reefs                  1,571 USD
+  2027-08-23  Ghazala Adventure      Brothers, Daedalus, Elphinstone        1,684 USD
+  2027-08-30  Ghazala Adventure      North & Brothers                       1,748 USD
+
+withdrawn (49)
+  2027-05-01  Blue Horizon           Brothers, Daedalus & Elphinstone      
+  2027-05-01  DUNE Longara           North Dahab Tiran                     
+  2027-05-01  Emperor Asmaa          Simply The Best                       
+  2027-05-01  Yachtiano              Yachtiano Deluxe                      
+  2027-05-08  Blue Horizon           Brothers, Daedalus & Elphinstone      
+  2027-05-08  DUNE Longara           Golden Triangle                       
+  2027-05-08  Emperor Asmaa          Daedalus, Fury and Elphinstone        
+  2027-05-08  Yachtiano              Yachtiano Deluxe                      
+  2027-05-15  Blue Horizon           Northern Red Sea & Brothers           
+  2027-05-15  DUNE Longara           Golden Triangle                       
+  2027-05-15  Emperor Asmaa          Simply the Best                       
+  2027-05-15  Yachtiano              Yachtiano Deluxe                      
+  ... and 37 more not shown
+
+174 further fare(s) moved by less than 2 — the source re-rounding, not a reprice; counted here rather than listed above
+
+fx: GBP 1.166317 -> 1.166589 (+0.02%) — every euro figure moves with it; no operator changed a price
+```
+

--- a/src/liveaboard/changes.py
+++ b/src/liveaboard/changes.py
@@ -40,6 +40,17 @@ from typing import Any
 
 Dataset = dict[str, Any]
 
+ROUNDING_MOVE = 2.0
+"""Below this a "price change" is the source rounding, not an operator.
+
+Measured, not guessed: on the 2026-08-28 refresh 174 fares "changed", and
+every single one of them by exactly -1 on a four-figure sum. Nobody reprices a
+1,469 berth by a dollar; the site had re-rounded. Left in, they filled both
+price blocks and pushed the real moves past the cap. Suppressed ones are still
+counted and still stated -- a report that quietly drops rows is the failure
+this project exists to correct in other people.
+"""
+
 MISSING_VESSEL_MIN = 3
 """Departures a vessel must lose *all* of before it counts as gone missing.
 
@@ -107,6 +118,8 @@ class Report:
     vessels_gone: list[str] = field(default_factory=list)
     """Vessels that lost every departure at once -- a failed fetch, most likely."""
     vessels_new: list[str] = field(default_factory=list)
+    price_rounding: int = 0
+    """Fares that moved by less than ``ROUNDING_MOVE`` -- counted, not listed."""
     availability_newly_read: bool = False
     """The older dataset stated availability nowhere, so no transition is real."""
     fx_was: float | None = None
@@ -271,6 +284,9 @@ def compare(before: Dataset, after: Dataset) -> Report:
         was, now = old_price.get("amount"), new_price.get("amount")
         if was is None or now is None or was == now:
             continue
+        if abs(now - was) < ROUNDING_MOVE:
+            report.price_rounding += 1
+            continue
         boat, title = _describe(new, new_its, new_boats)
         move = PriceMove(dep_id, boat, title, new.get("start", ""),
                          float(was), float(now), new_price.get("currency", ""))
@@ -312,6 +328,46 @@ def compare(before: Dataset, after: Dataset) -> Report:
     return report
 
 
+def headline(report: Report) -> str:
+    """One line, for the subject of the commit that carries the new dataset.
+
+    The refresh has always committed as "data: daily refresh <date>", which
+    tells a reader the pipeline ran and nothing about whether anything
+    happened. With this, ``git log --oneline data/`` *is* the changelog: the
+    history is already one commit per run, and the only thing missing was a
+    subject that said what the run found.
+
+    Ordered by what would make someone look: a vessel that went missing is a
+    broken fetch and comes first, then new stock, then money, then
+    availability. Everything else the full report has.
+    """
+    if report.vessels_gone:
+        return f"{len(report.vessels_gone)} vessel(s) lost every departure"
+
+    bits: list[str] = []
+    if report.vessels_new:
+        bits.append(f"{len(report.vessels_new)} new vessel(s)")
+    if report.added:
+        bits.append(f"{len(report.added)} new departures")
+    if report.withdrawn:
+        bits.append(f"{len(report.withdrawn)} withdrawn")
+    moved = len(report.price_up) + len(report.price_down)
+    if moved:
+        biggest = max(report.price_up + report.price_down, key=lambda m: abs(m.delta))
+        bits.append(f"{moved} prices moved (to {biggest.delta:+,.0f} "
+                    f"{biggest.currency} on {biggest.boat})")
+    if report.fees:
+        bits.append(f"{len(report.fees)} fee change(s)")
+    if report.sold_out:
+        bits.append(f"{len(report.sold_out)} sold out")
+    if report.returned:
+        bits.append(f"{len(report.returned)} bookable again")
+
+    if not bits:
+        return "no change to trips, prices or availability"
+    return ", ".join(bits[:3]) + (f", and {len(bits) - 3} more" if len(bits) > 3 else "")
+
+
 def render(report: Report, *, before: str = "", after: str = "", limit: int = 12) -> str:
     """The report as plain text, longest-first and capped.
 
@@ -327,7 +383,9 @@ def render(report: Report, *, before: str = "", after: str = "", limit: int = 12
     lines.append("=" * len(header))
 
     if report.is_quiet and not report.fx_moved and not report.availability_newly_read:
-        lines.append("\nnothing moved.")
+        lines.append("\nnothing moved." if not report.price_rounding else
+                     f"\nnothing moved, beyond {report.price_rounding} fare(s) "
+                     f"re-rounded by under {ROUNDING_MOVE:,.0f}.")
         return "\n".join(lines)
 
     if report.availability_newly_read:
@@ -374,6 +432,13 @@ def render(report: Report, *, before: str = "", after: str = "", limit: int = 12
         f"{f.boat:22.22} {f.code:16.16} {f.was} -> {f.now}" for f in report.fees])
     if report.vessels_new:
         block("vessels seen for the first time", report.vessels_new)
+
+    if report.price_rounding:
+        lines.append(
+            f"\n{report.price_rounding} further fare(s) moved by less than "
+            f"{ROUNDING_MOVE:,.0f} — the source re-rounding, not a reprice; "
+            "counted here rather than listed above"
+        )
 
     # Last, and separate: it explains a euro figure moving on every row, and it
     # is not an operator changing anything.

--- a/src/liveaboard/cli.py
+++ b/src/liveaboard/cli.py
@@ -559,9 +559,16 @@ def _git_show(revision: str, path: Path) -> dict[str, Any] | None:
         return None
 
 
+HISTORY_HEADER = (
+    "# What changed\n\n"
+    "One entry per refresh, newest first, written by `liveaboard.cli changes`.\n"
+    "Do not edit by hand — the next run rewrites the file around this header.\n"
+)
+
+
 def cmd_changes(args: argparse.Namespace) -> int:
     """Report what moved between two datasets."""
-    from .changes import compare, render as render_changes
+    from .changes import compare, headline, render as render_changes
 
     after = json.loads(Path(args.data).read_text(encoding="utf-8"))
 
@@ -575,10 +582,14 @@ def cmd_changes(args: argparse.Namespace) -> int:
             # Not a failure. A first run has nothing to compare against, and
             # saying so beats printing an empty report that reads as "nothing
             # changed" when the truth is "nothing to compare".
-            print(f"no earlier {args.data} at {args.revision}; nothing to compare")
+            print("first dataset; nothing to compare against" if args.headline
+                  else f"no earlier {args.data} at {args.revision}; nothing to compare")
             return 0
 
     report = compare(before, after)
+    if args.headline:
+        print(headline(report))
+        return 0
     text = render_changes(
         report,
         before=before_label,
@@ -591,6 +602,17 @@ def cmd_changes(args: argparse.Namespace) -> int:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)
         Path(args.out).write_text(text + "\n", encoding="utf-8")
         print(f"\nwrote {args.out}")
+
+    if args.append:
+        # Newest first, and committed: the workflow run summary vanishes with
+        # the run, so the only durable copy is the one in the repository.
+        path = Path(args.append)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        previous = path.read_text(encoding="utf-8") if path.exists() else ""
+        body = previous.split(HISTORY_HEADER, 1)[-1].lstrip("\n")
+        entry = f"## {after.get('generated') or before_label}\n\n```\n{text}\n```\n"
+        path.write_text(f"{HISTORY_HEADER}\n{entry}\n{body}", encoding="utf-8")
+        print(f"\nappended to {args.append}")
 
     # A vessel losing every departure at once is the one finding worth a
     # non-zero exit: it usually means a fetch failed rather than a season
@@ -676,6 +698,14 @@ def main(argv: list[str] | None = None) -> int:
         help="which commit to compare against when --before is not given",
     )
     changes.add_argument("--out", default=None, type=Path, help="also write the report here")
+    changes.add_argument(
+        "--append", default=None, type=Path,
+        help="prepend this run's entry to a running history file, newest first",
+    )
+    changes.add_argument(
+        "--headline", action="store_true",
+        help="print one line instead of the report, for a commit subject",
+    )
     changes.add_argument("--limit", type=int, default=12, help="rows per section")
     changes.add_argument(
         "--fail-on-missing", action="store_true",

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import unittest
 
-from liveaboard.changes import MISSING_VESSEL_MIN, compare, render
+from liveaboard.changes import (
+    MISSING_VESSEL_MIN, ROUNDING_MOVE, compare, headline, render,
+)
 
 
 def dataset(departures, itineraries=None, boats=None, fx=None):
@@ -164,6 +166,84 @@ class TestChangesThatDidNotHappen(unittest.TestCase):
                        "amount": {"amount": 80.0, "currency": "EUR"}}]}])
         codes = {(f.code, f.now) for f in compare(before, after).fees}
         self.assertIn(("marine_park", "no longer listed"), codes)
+
+
+class TestRoundingIsNotARepricing(unittest.TestCase):
+    """The real one, again. On 2026-08-28 every one of 174 "price changes"
+    was exactly -1 on a four-figure fare: the source had re-rounded. Left in,
+    they filled both price blocks and pushed the real moves past the cap."""
+
+    def test_a_one_unit_move_is_not_listed(self):
+        report = compare(
+            dataset([departure("d1", price=1469.0)]),
+            dataset([departure("d1", price=1468.0)]),
+        )
+        self.assertFalse(report.price_down)
+        self.assertEqual(report.price_rounding, 1)
+
+    def test_it_is_counted_and_said_out_loud(self):
+        """Suppressed, never silently dropped."""
+        before = dataset([departure(f"d{i}", price=1000.0) for i in range(3)])
+        after = dataset([departure(f"d{i}", price=999.0) for i in range(3)]
+                        + [departure("new", start="2027-06-05")])
+        text = render(compare(before, after))
+        self.assertIn("3 further fare(s) moved by less than", text)
+
+    def test_a_real_move_still_gets_through(self):
+        report = compare(
+            dataset([departure("d1", price=1000.0)]),
+            dataset([departure("d1", price=1000.0 + ROUNDING_MOVE)]),
+        )
+        self.assertEqual(len(report.price_up), 1)
+        self.assertEqual(report.price_rounding, 0)
+
+    def test_rounding_alone_is_still_a_quiet_run(self):
+        report = compare(
+            dataset([departure("d1", price=1000.0)]),
+            dataset([departure("d1", price=999.0)]),
+        )
+        self.assertTrue(report.is_quiet)
+        self.assertIn("re-rounded", render(report))
+
+
+class TestHeadline(unittest.TestCase):
+    """One line for the commit subject, so `git log` is the changelog."""
+
+    def test_a_quiet_run_says_nothing_changed(self):
+        report = compare(dataset([departure("d1")]), dataset([departure("d1")]))
+        self.assertEqual(headline(report), "no change to trips, prices or availability")
+
+    def test_a_missing_vessel_outranks_everything_else(self):
+        """It means a fetch broke, and it is the one thing worth interrupting
+        a reader for -- so it must not be buried behind eighty withdrawals."""
+        deps = [departure(f"d{i}", start=f"2027-05-{i+1:02}")
+                for i in range(MISSING_VESSEL_MIN + 2)]
+        line = headline(compare(dataset(deps), dataset([])))
+        self.assertIn("lost every departure", line)
+
+    def test_new_departures_are_counted(self):
+        report = compare(
+            dataset([departure("d1")]),
+            dataset([departure("d1"), departure("d2", start="2027-05-08")]),
+        )
+        self.assertIn("1 new departures", headline(report))
+
+    def test_a_price_move_names_the_biggest(self):
+        report = compare(
+            dataset([departure("d1", price=1000.0)]),
+            dataset([departure("d1", price=1200.0)]),
+        )
+        line = headline(report)
+        self.assertIn("+200 USD", line)
+        self.assertIn("Alia Soul", line)
+
+    def test_it_is_always_one_line(self):
+        """It becomes a commit subject; a newline would split the message."""
+        before = dataset([departure(f"d{i}", price=1000.0) for i in range(8)])
+        after = dataset([departure(f"d{i}", price=1000.0 + i * 50) for i in range(8)]
+                        + [departure("new", start="2027-06-05")])
+        for report in (compare(before, after), compare(after, before)):
+            self.assertNotIn("\n", headline(report))
 
 
 class TestSoldOutAndWithdrawnAreDifferent(unittest.TestCase):


### PR DESCRIPTION
The change report existed and only ever reached the workflow run summary, which disappears when the run ages out. Meanwhile 23 data commits all read `data: daily refresh <date>`, so `git log --oneline data/` told a reader the pipeline ran and nothing about whether anything happened.

## Three destinations, one comparison

- the run summary, as before;
- **`data/CHANGES.md`** — committed, newest first, so the whole history is one file in the repo;
- the **subject of the data commit**, so `git log --oneline data/` is the changelog:

```
data: daily refresh 2026-08-29 — 6 new departures, 49 withdrawn
```

`headline()` leads with a vessel that lost every departure, because that means a fetch broke and it must not sit behind eighty withdrawals nobody caused.

## Rounding was drowning the report

Verified against three real historical datasets from git rather than fixtures, which is how this surfaced. On the 2026-08-28 refresh 174 fares "changed" — every single one by exactly `-1` on a four-figure sum. The source had re-rounded. They filled both price blocks and pushed the real moves past the cap:

```
price down (174)
  2027-05-08  ALSURAYA    1,469 -> 1,468 USD  (-0%)
  ... and 162 more not shown
```

They are now suppressed below `ROUNDING_MOVE`, but counted and stated — `174 further fare(s) moved by less than 2 — the source re-rounding, not a reprice`. Silently dropping rows is the failure this project exists to correct in other people, so it is never silent.

## Notes

- The headline reaches the shell through the environment rather than `${{ }}`: it carries boat names read off somebody else's web page.
- 445 tests (13 new, covering the rounding rule and the headline); `promote --check` and `check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_