### PR TITLE
Ask a page that answers nothing a second time

### DIFF
--- a/.github/workflows/probe.yml
+++ b/.github/workflows/probe.yml
@@ -26,6 +26,10 @@ on:
         description: "Print the modal's markup, not just its text"
         type: boolean
         default: false
+      unread_retries:
+        description: "Fetches per unreadable page, to tell transient from persistent"
+        type: string
+        default: "2"
 
 permissions:
   contents: read
@@ -57,6 +61,16 @@ jobs:
       # so it is read before anything is written against it.
       - name: Read the Route block nothing has parsed
         run: python3 tools/probe_itinerary_route.py --boats 6
+
+      # The pages the last crawl could not read at all. Fourteen of them on
+      # 2026-08-28, and publishing their absence deleted 49 real, bookable
+      # sailings. carry_unread stops the site lying about them; this settles
+      # what to actually do -- retry, markup parser, or neither -- by reading
+      # what the pages return rather than guessing at it.
+      - name: Re-read the pages the crawl could not
+        run: |
+          python3 tools/probe_unread.py \
+            --retries "${{ inputs.unread_retries || 2 }}"
 
   # Separate job: the gear modal is built client-side, so this one needs a
   # browser and the plain-HTTP probes above do not.

--- a/.github/workflows/probe.yml
+++ b/.github/workflows/probe.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Read the Route block nothing has parsed
         run: python3 tools/probe_itinerary_route.py --boats 6
 
+  # Its own job, not another step above: fourteen pages at two fetches each,
+  # paced by the crawl delay, is minutes on its own and the probe job is
+  # already close to its budget. It is also a different question from the rest
+  # of them, and worth being able to read — or re-run — by itself.
+  unread:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       # The pages the last crawl could not read at all. Fourteen of them on
       # 2026-08-28, and publishing their absence deleted 49 real, bookable
       # sailings. carry_unread stops the site lying about them; this settles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ price and reassembles the real bill. See README.md for the domain.
 ## Commands
 
 ```bash
-PYTHONPATH=src python3 -m unittest discover -s tests   # 462 tests, no deps
+PYTHONPATH=src python3 -m unittest discover -s tests   # 465 tests, no deps
 PYTHONPATH=src python3 -m liveaboard.cli check         # validate + summarise
 PYTHONPATH=src python3 -m liveaboard.cli build         # -> site/index.html
 PYTHONPATH=src python3 -m liveaboard.cli changes       # what moved since HEAD~1
@@ -113,8 +113,11 @@ Break these and the site starts lying quietly rather than failing loudly.
   keeping each row's original `retrieved` date, and says so. The distinction is
   the source's own: a *Product* node with no *Event* nodes is a boat selling
   nothing that month and its absence is the answer; no structured data at all
-  answers nothing. Same rule as the fee book — a run that could not look at
-  something knows nothing about it.
+  answers nothing. Probed rather than guessed: 13 of the 14 answered in full
+  on the first retry, so `PARSE_ATTEMPTS = 2` asks again and `carry_unread` is
+  the net under a page that fails twice. A markup parser for them is ruled
+  out — the JSON-LD is there, it just occasionally is not served. Same rule as
+  the fee book: a run that could not look at something knows nothing about it.
 - **A change report never drops a row silently.** `changes` caps its blocks and
   suppresses sub-unit price moves as source rounding — and says so, with a
   count, every time. A truncated list that does not admit it reads as "that was

--- a/README.md
+++ b/README.md
@@ -160,9 +160,16 @@ sailings, DUNE Longara's whole May among them.
 
 The source itself distinguishes the two, and now so does the scrape: a
 `Product` node with no `Event` nodes is a boat selling nothing that month, and
-its absence is the answer; no structured data at all answers nothing. For the
-second, `scrape` carries the previous run's departures forward for up to a
-fortnight, keeping each row's original `retrieved` date so the page still says
+its absence is the answer; no structured data at all answers nothing.
+
+A probe re-read all fourteen and **thirteen answered in full on the first
+retry** — the fourteenth was a genuinely empty month. So the failure is the
+response and not the page: the crawl now asks a second time, which recovers
+them. A markup parser is ruled out; the JSON-LD is there, it just occasionally
+is not served.
+
+Where a page answers nothing twice, `scrape` carries the previous run's
+departures forward for up to a fortnight, keeping each row's original `retrieved` date so the page still says
 when every price was last read, and noting each carried page in the candidate's
 warnings. After that they drop out — a page unread for two weeks is one we can
 no longer claim to see. The same rule the fee book already followed: a run that

--- a/docs/sources/liveaboard.com.md
+++ b/docs/sources/liveaboard.com.md
@@ -196,11 +196,21 @@ Each of these cost a cycle at least once.
 
   Treating the second as the first deleted 49 real, bookable sailings from the
   site — DUNE Longara's entire May, still on sale at the source — and the
-  change report called them withdrawn. `scrape` now carries those departures
-  forward from the previous candidate (`carry_unread`, `CARRY_MAX_DAYS`).
-  **Do not "fix" this by writing a markup parser for those pages before
-  probing one**: nobody has yet checked whether the HTML carries the
-  departures when the JSON-LD does not.
+  change report called them withdrawn.
+
+  **Probed, and it is transient.** `tools/probe_unread.py` re-read all
+  fourteen (run 33206151057): **thirteen answered in full on the very first
+  retry** — DUNE Longara's May came back with its 5 Events, Blue Horizon's
+  with 5, Yachtiano's three months with 5/4/5 — and the fourteenth,
+  `bismarck?m=5/2027`, returned a `Product` with no Events, which is a real
+  empty month. Bodies were normal size (0.9–1.1 MB) on both the failing and
+  the succeeding fetch, so it is not a truncation or a bot wall.
+
+  So the answer is **a retry, not a markup parser**: `PARSE_ATTEMPTS = 2` in
+  `scrape/base.py`, with `PoliteFetcher.forget()` to make the second attempt a
+  real request. `carry_unread` stays as the net under a page that fails twice.
+  A markup parser for these pages is ruled out and should not be revisited —
+  the JSON-LD is there, it just occasionally is not served.
 - **`?m=` is zero-padded in the data and unpadded in our crawl.**
   `Offer.url` says `?m=05/2027`; `SEASON_QUERIES` builds `?m=5/2027`. Both
   work — worth knowing before treating one as canonical.

--- a/src/liveaboard/scrape/base.py
+++ b/src/liveaboard/scrape/base.py
@@ -33,6 +33,21 @@ USER_AGENT = (
 )
 
 DEFAULT_DELAY_SECONDS = 5.0
+
+PARSE_ATTEMPTS = 2
+"""How many times to ask for a page that comes back without structured data.
+
+Measured, not assumed. Fourteen vessel-month pages returned no JSON-LD at all
+on 2026-08-28; a probe re-read all fourteen and thirteen answered in full on
+the very first retry, the fourteenth being a genuinely empty month. So the
+failure is the response, not the page, and one more request settles it --
+against 49 real, bookable sailings that the first version of this loop deleted
+from the site by believing the empty answer.
+
+Two, not more: the pages that fail are a handful out of 268, the retry is
+paced by the same crawl delay as everything else, and a page that answers
+nothing twice is a genuine unknown that `carry_unread` then covers.
+"""
 """Conservative default for a host nobody has checked.
 
 Slower than necessary on purpose: this scrape has a whole day to finish and
@@ -138,6 +153,16 @@ class PoliteFetcher:
         if elapsed < delay:
             time.sleep(delay - elapsed)
         self._last_request[host] = time.monotonic()
+
+    def forget(self, url: str) -> None:
+        """Drop one cached body so the next ``get`` is a real request.
+
+        For the one case where the cache is the wrong answer: a page that came
+        back without its structured data. Asking again through the cache would
+        hand back the same nothing, and the whole point of a retry is to find
+        out whether the *response* was the problem.
+        """
+        self._cache.pop(url, None)
 
     def get(self, url: str) -> FetchResult:
         """Fetch one URL, refusing if robots.txt disallows it."""
@@ -345,11 +370,34 @@ class SourceAdapter(ABC):
                 output.unread.append(url)
                 continue
             fetched += 1
-            try:
-                output.extend(self.parse(result))
-            except ScrapeError as exc:
-                output.warnings.append(f"unparsed {url}: {exc}")
+
+            error: ScrapeError | None = None
+            for attempt in range(PARSE_ATTEMPTS):
+                if attempt:
+                    # The cached body is the one that just failed, so asking
+                    # again through the cache would return the same nothing.
+                    self.fetcher.forget(url)
+                    try:
+                        result = self.fetcher.get(url)
+                    except FetchBlocked as exc:
+                        error = ScrapeError(str(exc))
+                        break
+                    fetched += 1
+                try:
+                    output.extend(self.parse(result))
+                    error = None
+                    break
+                except ScrapeError as exc:
+                    error = exc
+
+            if error is not None:
+                output.warnings.append(f"unparsed {url}: {error}")
                 output.unread.append(url)
+            elif attempt:
+                output.warnings.append(
+                    f"re-read {url} on attempt {attempt + 1}; the first "
+                    f"response carried no structured data"
+                )
 
         output.warnings.extend(self._notes)
         if fetched == 0:

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -12,6 +12,9 @@ from liveaboard.scrape.base import (
     DEFAULT_DELAY_SECONDS,
     FetchResult,
     PoliteFetcher,
+    ScrapeError,
+    ScrapeOutput,
+    SourceAdapter,
 )
 from liveaboard.scrape.liveaboard_com import LiveaboardComAdapter, _iso_date
 
@@ -355,3 +358,85 @@ class _FetcherReturning:
             url=url, status=200, body=self.body,
             fetched_at=datetime.now(timezone.utc), from_cache=False,
         )
+
+
+class TestAPageThatAnswersNothingIsAskedAgain(unittest.TestCase):
+    """A response with no structured data is not a month with no trips.
+
+    Fourteen vessel-month pages came back with no JSON-LD on 2026-08-28 and
+    the crawl believed every one of them, deleting 49 real, bookable sailings
+    -- DUNE Longara's whole May, still on sale at the source. A probe re-read
+    all fourteen: thirteen answered in full on the first retry, and the
+    fourteenth was a genuinely empty month. The failure is the response.
+    """
+
+    class _Adapter(SourceAdapter):
+        source_id = "test"
+        host = "example.test"
+
+        def __init__(self, fetcher, fail_times: int):
+            super().__init__(fetcher)
+            self.fail_times = fail_times
+            self.parses = 0
+
+        def preflight(self) -> None:
+            """No robots check: the stub fetcher is not a PoliteFetcher."""
+
+        def discover(self):
+            yield "https://example.test/boat?m=5/2027"
+
+        def parse(self, result):
+            self.parses += 1
+            if self.parses <= self.fail_times:
+                raise ScrapeError("no JSON-LD Event or Product node")
+            out = ScrapeOutput()
+            out.departures.append({"id": "d1"})
+            return out
+
+    class _CountingFetcher:
+        """Counts real requests, and honours forget() like the real one."""
+
+        def __init__(self):
+            self.requests = 0
+            self._cache: dict[str, object] = {}
+
+        def forget(self, url):
+            self._cache.pop(url, None)
+
+        def get(self, url):
+            from datetime import datetime, timezone
+
+            if url in self._cache:
+                return self._cache[url]
+            self.requests += 1
+            result = FetchResult(url=url, status=200, body="<html></html>",
+                                 fetched_at=datetime.now(timezone.utc))
+            self._cache[url] = result
+            return result
+
+    def test_a_transient_empty_response_is_retried_and_recovered(self):
+        fetcher = self._CountingFetcher()
+        adapter = self._Adapter(fetcher, fail_times=1)
+        output = adapter.run()
+        self.assertEqual(len(output.departures), 1)
+        self.assertEqual(output.unread, [])
+        self.assertEqual(fetcher.requests, 2, "the retry must be a real request")
+        self.assertTrue(any("re-read" in w for w in output.warnings),
+                        "a recovered page is said out loud, not silently fixed")
+
+    def test_a_page_that_fails_twice_is_still_reported_unread(self):
+        """carry_unread is the net under this, and it needs to be told."""
+        fetcher = self._CountingFetcher()
+        adapter = self._Adapter(fetcher, fail_times=99)
+        output = adapter.run()
+        self.assertEqual(len(output.unread), 1)
+        self.assertTrue(any("unparsed" in w for w in output.warnings))
+
+    def test_a_page_that_reads_first_time_is_fetched_once(self):
+        """The retry must cost nothing on the 254 pages that are fine."""
+        fetcher = self._CountingFetcher()
+        adapter = self._Adapter(fetcher, fail_times=0)
+        output = adapter.run()
+        self.assertEqual(fetcher.requests, 1)
+        self.assertEqual(len(output.departures), 1)
+        self.assertFalse(any("re-read" in w for w in output.warnings))

--- a/tools/probe_unread.py
+++ b/tools/probe_unread.py
@@ -125,9 +125,8 @@ def main() -> int:
         for attempt in range(1, args.retries + 1):
             # The whole question is whether a second *real* request answers
             # differently, and the fetcher's cache would hand back the first
-            # body. Dropping the entry is the probe's business, not a reason to
-            # widen `get()` for production code that always wants the cache.
-            fetcher._cache.pop(url, None)  # noqa: SLF001
+            # body.
+            fetcher.forget(url)
             try:
                 result = fetcher.get(url)
             except FetchBlocked as exc:

--- a/tools/probe_unread.py
+++ b/tools/probe_unread.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Read the vessel-month pages the crawl could not, and say why.
+
+On 2026-08-28 fourteen vessel-month pages came back with no JSON-LD at all --
+no ``Event`` nodes and no ``Product`` node -- while forty-two others came back
+with a ``Product`` and no ``Event``. The two look identical to a parser that
+only asks "how many departures did I get?", and treating them alike deleted 49
+real, bookable sailings from the site: DUNE Longara's entire May, still on sale
+at the source.
+
+``carry_unread`` now keeps those departures rather than publishing their
+absence, which stops the site lying. It does not recover the *current* prices,
+and it cannot: it republishes the last reading. So the question this probe
+exists to settle, before any parser is written:
+
+1. **Is it transient?** Re-fetch the same URL. If it comes back with its
+   JSON-LD, the answer is a retry in the crawl and nothing else.
+2. **If it fails again, is the data in the HTML anyway?** The page may render
+   its departures in markup while omitting the structured data, in which case a
+   markup parser is worth writing. Or the body may be a bot wall, a JS shell,
+   or a redirect -- each of which needs a different answer, and none of which is
+   a parser.
+
+This writes nothing and parses nothing into the dataset. It exists so that
+nobody writes a markup parser for a page nobody has read, which is the rule.
+
+Run from CI; a development sandbox cannot reach the host.
+
+    python3 tools/probe_unread.py [--candidate data/candidate.json] [--retries 2]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from liveaboard.scrape import jsonld  # noqa: E402
+from liveaboard.scrape.base import FetchBlocked, PoliteFetcher  # noqa: E402
+
+# Greedy, then a colon *and a space*: the URL itself contains colons, and a
+# non-greedy match stopped at the one in "https:".
+UNPARSED = re.compile(r"^unparsed (\S+): ")
+
+# Shapes worth telling apart in a body with no JSON-LD. None of these is a
+# parser; each is a different answer to "what do we do about it?".
+TELLS: tuple[tuple[str, str], ...] = (
+    ("captcha", "bot wall"),
+    ("cf-browser-verification", "Cloudflare interstitial"),
+    ("Just a moment", "Cloudflare interstitial"),
+    ("Access Denied", "access denied"),
+    ("<noscript>", "may need JavaScript"),
+)
+
+# Markup that would carry a departure if the page renders them without
+# structured data. Deliberately loose: this reports what is there, and a real
+# parser gets written afterwards against what this prints.
+DEPARTURE_HINTS: tuple[tuple[str, str], ...] = (
+    (r"\bm=\d{1,2}/20\d\d", "month links"),
+    (r"20\d\d-\d\d-\d\d", "ISO dates"),
+    (r"\b\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)", "written dates"),
+    (r"(US\$|€|\$)\s?\d[\d,]{2,}", "prices"),
+    (r"data-tour-?id", "tour ids"),
+    (r"sold\s?out", "availability wording"),
+)
+
+
+def unread_urls(candidate: Path) -> list[str]:
+    """The pages last run recorded as unreadable, from its own warnings."""
+    if not candidate.exists():
+        return []
+    data = json.loads(candidate.read_text(encoding="utf-8"))
+    found = []
+    for warning in data.get("warnings", []):
+        match = UNPARSED.match(warning)
+        if match:
+            found.append(match.group(1))
+    return sorted(dict.fromkeys(found))
+
+
+def describe(body: str) -> tuple[int, int, list[str]]:
+    """Event nodes, Product nodes, and what the body looks like."""
+    try:
+        events = len(jsonld.of_type(body, "Event", "TouristTrip", "Trip"))
+        products = len(jsonld.of_type(body, "Product"))
+    except Exception:  # noqa: BLE001 - a probe must not die on one odd body
+        events = products = 0
+    notes = [label for needle, label in TELLS if needle.lower() in body.lower()]
+    return events, products, notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", default=Path("data/candidate.json"), type=Path)
+    parser.add_argument("--snapshots", default=Path("data/snapshots"), type=Path)
+    parser.add_argument("--retries", type=int, default=2,
+                        help="fetches per URL, to tell transient from persistent")
+    parser.add_argument("--chars", type=int, default=1200,
+                        help="body to print when a page has no JSON-LD twice")
+    parser.add_argument("--urls", default="",
+                        help="comma-separated URLs, instead of the candidate's")
+    args = parser.parse_args()
+
+    urls = ([u.strip() for u in args.urls.split(",") if u.strip()]
+            or unread_urls(args.candidate))
+    if not urls:
+        print("no unreadable pages recorded in the last candidate — nothing to probe")
+        return 0
+
+    fetcher = PoliteFetcher(snapshot_dir=args.snapshots)
+    print(f"{len(urls)} page(s) the last crawl could not read, "
+          f"{args.retries} fetch(es) each\n")
+
+    recovered, persistent, blocked = [], [], []
+
+    for n, url in enumerate(urls, 1):
+        print("=" * 78)
+        print(f"[{n}/{len(urls)}] {url}")
+        last_body = ""
+        outcome = "no JSON-LD"
+        for attempt in range(1, args.retries + 1):
+            # The whole question is whether a second *real* request answers
+            # differently, and the fetcher's cache would hand back the first
+            # body. Dropping the entry is the probe's business, not a reason to
+            # widen `get()` for production code that always wants the cache.
+            fetcher._cache.pop(url, None)  # noqa: SLF001
+            try:
+                result = fetcher.get(url)
+            except FetchBlocked as exc:
+                print(f"    attempt {attempt}: blocked — {exc}")
+                outcome = "blocked"
+                continue
+            except Exception as exc:  # noqa: BLE001 - one bad page must not end the run
+                print(f"    attempt {attempt}: failed — {exc}")
+                outcome = "error"
+                continue
+            last_body = result.body
+            events, products, notes = describe(result.body)
+            print(f"    attempt {attempt}: {len(result.body):>7,} bytes, "
+                  f"{events} Event, {products} Product"
+                  + (f"  [{', '.join(notes)}]" if notes else ""))
+            if events:
+                outcome = "recovered"
+                break
+            if products:
+                outcome = "empty month (Product, no Event)"
+                break
+
+        if outcome == "recovered":
+            recovered.append(url)
+            print("    -> reads fine on a retry; this was transient")
+            continue
+        if outcome == "blocked":
+            blocked.append(url)
+            continue
+        if outcome.startswith("empty month"):
+            print("    -> a real empty month, not a failure")
+            continue
+
+        persistent.append(url)
+        # The part that decides whether a markup parser is even possible.
+        hits = [label for pattern, label in DEPARTURE_HINTS
+                if re.search(pattern, last_body, re.I)]
+        print(f"    -> still no structured data. In the HTML: "
+              f"{', '.join(hits) if hits else 'none of the departure markers'}")
+        print(f"    --- first {args.chars} chars ---")
+        print("    " + last_body[: args.chars].replace("\n", "\n    "))
+
+    print("\n" + "=" * 78)
+    print("SUMMARY")
+    print(f"  recovered on retry : {len(recovered)}")
+    print(f"  still unreadable   : {len(persistent)}")
+    print(f"  blocked            : {len(blocked)}")
+    for url in persistent:
+        print(f"    still unreadable: {url}")
+    print()
+    if recovered and not persistent:
+        print("  Every one read on a retry. The answer is a retry in the crawl,")
+        print("  not a markup parser. carry_unread stays as the safety net.")
+    elif persistent:
+        print("  Some pages answer nothing twice. Read the bodies above before")
+        print("  writing anything: what is in them decides whether a markup")
+        print("  parser is possible at all.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to #76, which stopped unreadable vessel-month pages *deleting* trips but only republished the last reading. This settles what the actual repair is — by probing, not guessing.

## What the probe found

`tools/probe_unread.py` re-read all fourteen pages the crawl could not read on 2026-08-28, from a runner ([run 33206151057](https://github.com/PaludaNCode/Liveaboard/actions/runs/33206151057)). It reads the URLs out of the last candidate's own warnings, so it always probes what actually failed rather than a list that goes stale.

**Thirteen answered in full on the very first retry:**

```
dune-longara?m=5/2027   5 Events   <- the five May sailings that vanished
blue-horizon?m=5/2027   5 Events
yachtiano?m=5,6,7/2027  5, 4, 5 Events
discovery-ii?m=6,8      4, 4 Events
...
bismarck?m=5/2027       Product node, 0 Events  <- a genuinely empty month
```

Bodies were normal size on both the failing and the succeeding fetch — 0.9 to 1.1 MB — so it is not a truncation, a bot wall or an interstitial. The JSON-LD is there; it just occasionally is not served.

## The fix

A retry, not a markup parser. `PARSE_ATTEMPTS = 2` in `scrape/base.py`, with a new `PoliteFetcher.forget()` so the second attempt is a real request rather than the cached body that just failed — asking the cache again would return the same nothing. A recovered page says so in the warnings rather than being silently patched up.

Two, not more: the pages that fail are a handful out of 268, the retry is paced by the same crawl delay as everything else, and it costs nothing on the 254 that read first time — pinned by a test, because a retry firing on every page would quietly double the crawl.

`carry_unread` stays as the net under a page that answers nothing twice. The defence is layered now: **retry** recovers 13/14 → **carry forward** covers what retries cannot → **the change report** flags a vessel-month that emptied instead of calling it a withdrawal.

## Recorded as ruled out

`docs/sources/liveaboard.com.md` now says a markup parser for these pages is ruled out and should not be revisited — a lead ruled out and not written down gets followed again.

## Caveat

The probe ran ~24 hours after the failures, so it shows these URLs serve their JSON-LD reliably *now*, not that a retry always lands. If the source has a bad minute rather than a bad response, two attempts seconds apart could both miss — which is what `carry_unread` is for, and the warnings will show it if it starts happening.

465 tests; `promote --check` and `check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_