### PR TITLE
Remove the Entry column

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1107,25 +1107,6 @@ vessels seen for the first time (2)
 
   /* ---------- columns ---------- */
 
-  /* The entry bar an operator stated, and whether the two sources agree on it.
-   *
-   * This is not the inferred "level" the site used to print beside a route and
-   * a theme; those were ours and are gone. This is the operator's own claim,
-   * and where liveaboard.com and PADI Travel state different bars the stricter
-   * is shown -- so the visitor is told, rather than shown one number as though
-   * it were settled. A trip nobody has read shows nothing at all. */
-  function entry(itin) {
-    var req = itin.requirements;
-    if (!req || !req.min_level) return null;
-    var label = D.level_labels[req.min_level] || req.min_level;
-    var note = req.notes || "";
-    return {
-      label: label,
-      disputed: note.indexOf("Sources disagree") === 0 || note.indexOf("Sources disagree") > 0,
-      note: note
-    };
-  }
-
   function disclosure(dep) {
     if (!dep.fees_known) return ["none", "not looked at"];
     if (!dep.mandatory_known) return ["partial", "optional only"];
@@ -1276,23 +1257,6 @@ vessels seen for the first time (2)
         if (d.availability === "limited") return '<span class="pill few">few left</span>';
         if (d.availability === "available") return '<span class="pill open">available</span>';
         return '<span class="dim">—</span>';
-      } },
-    /* Sorted by how demanding the bar is, not alphabetically: "Advanced + 100
-       dives" sorting under "Open Water" would put the hardest trip above the
-       easiest. */
-    { k: "entry", t: "Entry",
-      v: function (d, i) {
-        var e = entry(i);
-        if (!e) return -1;
-        var order = Object.keys(D.level_labels);
-        return order.indexOf(i.requirements.min_level);
-      },
-      show: function (d, i) {
-        var e = entry(i);
-        if (!e) return '<span class="dim">not stated</span>';
-        if (!e.disputed) return esc(e.label);
-        return '<span class="pill partial" title="' + esc(e.note) + '">' +
-          esc(e.label) + " ?</span>";
       } },
     { k: "disclosure", t: "Disclosure", v: function (d) { return disclosure(d)[1]; },
       show: function (d) {

--- a/src/liveaboard/render.py
+++ b/src/liveaboard/render.py
@@ -181,9 +181,11 @@ def build_payload(dataset: Dataset) -> dict[str, Any]:
             ],
         },
         "fee_labels": {code.value: label for code, label in FEE_LABELS.items()},
-        # Shipped rather than restated in the browser, for the same reason the
-        # fee labels are: one vocabulary, defined once. The page needs them to
-        # print an entry bar the operator stated.
+        # Shipped for the same reason the fee labels are: one vocabulary,
+        # defined once. Nothing on the page prints these today -- the Entry
+        # column that did was removed as noise -- but the bar is in every
+        # itinerary record and in the published downloads, so a reader who
+        # wants it has the vocabulary to read it with.
         "level_labels": {
             level.value: label for level, label in DIVER_LEVEL_LABELS.items()
         },

--- a/templates/app.js
+++ b/templates/app.js
@@ -184,25 +184,6 @@
 
   /* ---------- columns ---------- */
 
-  /* The entry bar an operator stated, and whether the two sources agree on it.
-   *
-   * This is not the inferred "level" the site used to print beside a route and
-   * a theme; those were ours and are gone. This is the operator's own claim,
-   * and where liveaboard.com and PADI Travel state different bars the stricter
-   * is shown -- so the visitor is told, rather than shown one number as though
-   * it were settled. A trip nobody has read shows nothing at all. */
-  function entry(itin) {
-    var req = itin.requirements;
-    if (!req || !req.min_level) return null;
-    var label = D.level_labels[req.min_level] || req.min_level;
-    var note = req.notes || "";
-    return {
-      label: label,
-      disputed: note.indexOf("Sources disagree") === 0 || note.indexOf("Sources disagree") > 0,
-      note: note
-    };
-  }
-
   function disclosure(dep) {
     if (!dep.fees_known) return ["none", "not looked at"];
     if (!dep.mandatory_known) return ["partial", "optional only"];
@@ -353,23 +334,6 @@
         if (d.availability === "limited") return '<span class="pill few">few left</span>';
         if (d.availability === "available") return '<span class="pill open">available</span>';
         return '<span class="dim">—</span>';
-      } },
-    /* Sorted by how demanding the bar is, not alphabetically: "Advanced + 100
-       dives" sorting under "Open Water" would put the hardest trip above the
-       easiest. */
-    { k: "entry", t: "Entry",
-      v: function (d, i) {
-        var e = entry(i);
-        if (!e) return -1;
-        var order = Object.keys(D.level_labels);
-        return order.indexOf(i.requirements.min_level);
-      },
-      show: function (d, i) {
-        var e = entry(i);
-        if (!e) return '<span class="dim">not stated</span>';
-        if (!e.disputed) return esc(e.label);
-        return '<span class="pill partial" title="' + esc(e.note) + '">' +
-          esc(e.label) + " ?</span>";
       } },
     { k: "disclosure", t: "Disclosure", v: function (d) { return disclosure(d)[1]; },
       show: function (d) {


### PR DESCRIPTION
It earned a column and did not deserve one.

Sixteen columns already compete for the width, the bar reads the same three words on most rows, and the disputed marker reused the disclosure pill's styling — so *"two sources disagree about the entry bar"* and *"the operator did not state its required fees"* sat in adjacent columns looking identical.

## Nothing about the data changes

- The bar is still resolved to the stricter of liveaboard.com and PADI Travel
- The disagreement is still recorded in each itinerary's `notes`
- Both still ship in `data/egypt-2027.json` and in the two source books published beside the page

A reader who wants the entry bar can have it. The table stops spending a column on it.

`level_labels` stays in the payload — nothing prints it today, but the bar is in every itinerary record and a reader needs the vocabulary to read it with.

554 tests, `promote --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFN6PnZAL4svAiZSMHg2py)_