### PR TITLE
Place the PADI column at every width, and test that every column is placed

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1326,7 +1326,7 @@ vessels seen for the first time (2)
   var ORDER = [
     "start", "end", "boat", "guests",
     "from", "to", "trip", "sites",
-    "base", "nitrox", "later", "total", "perdive",
+    "base", "nitrox", "later", "total", "perdive", "padi",
     "availability", "disclosure", "source"
   ];
   /* The same columns on a phone, and as much of the same order as 390px holds.
@@ -1359,7 +1359,7 @@ vessels seen for the first time (2)
        Advertised, Nitrox, Mandatory fees -- rather than in a third order
        invented for this width. Scrolling right reads the bill; not scrolling
        still shows the answer. */
-    "total", "base", "nitrox", "later", "perdive",
+    "total", "base", "nitrox", "later", "perdive", "padi",
     "end", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];
@@ -1378,7 +1378,7 @@ vessels seen for the first time (2)
      silent -- the row still renders, it just does not answer the question. */
   var TINY_ORDER = [
     "start", "boat",
-    "total", "base", "nitrox", "later", "perdive",
+    "total", "base", "nitrox", "later", "perdive", "padi",
     "guests", "end", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];
@@ -1396,7 +1396,7 @@ vessels seen for the first time (2)
      Total, in that order still. */
   var COMPACT_ORDER = [
     "start", "end", "boat",
-    "base", "nitrox", "later", "total", "perdive",
+    "base", "nitrox", "later", "total", "perdive", "padi",
     "guests", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];

--- a/templates/app.js
+++ b/templates/app.js
@@ -395,7 +395,7 @@
   var ORDER = [
     "start", "end", "boat", "guests",
     "from", "to", "trip", "sites",
-    "base", "nitrox", "later", "total", "perdive",
+    "base", "nitrox", "later", "total", "perdive", "padi",
     "availability", "disclosure", "source"
   ];
   /* The same columns on a phone, and as much of the same order as 390px holds.
@@ -428,7 +428,7 @@
        Advertised, Nitrox, Mandatory fees -- rather than in a third order
        invented for this width. Scrolling right reads the bill; not scrolling
        still shows the answer. */
-    "total", "base", "nitrox", "later", "perdive",
+    "total", "base", "nitrox", "later", "perdive", "padi",
     "end", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];
@@ -447,7 +447,7 @@
      silent -- the row still renders, it just does not answer the question. */
   var TINY_ORDER = [
     "start", "boat",
-    "total", "base", "nitrox", "later", "perdive",
+    "total", "base", "nitrox", "later", "perdive", "padi",
     "guests", "end", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];
@@ -465,7 +465,7 @@
      Total, in that order still. */
   var COMPACT_ORDER = [
     "start", "end", "boat",
-    "base", "nitrox", "later", "total", "perdive",
+    "base", "nitrox", "later", "total", "perdive", "padi",
     "guests", "from", "to", "trip", "sites",
     "availability", "disclosure", "source"
   ];

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -678,3 +678,69 @@ class TestThePayloadShipsOnlyWhatThePageReads(unittest.TestCase):
                 with self.subTest(code=line["code"], key=key):
                     self.assertIsNotNone(value, f"{key} ships as null")
                     self.assertIsNot(value, False, f"{key} ships as false")
+
+
+class TestColumnOrders(unittest.TestCase):
+    """Every column has a place at every width.
+
+    app.js orders its columns from four lists -- one per breakpoint -- and
+    appends anything missing from one, with a console.warn nobody sees unless
+    they have devtools open. A column added to COLS and to the widest list only
+    looks correct on the laptop it was written on and falls off the right-hand
+    edge of a phone, which is the device most people open this page on.
+
+    That is exactly what happened when the "vs PADI" column was added, and it
+    reached production. A warning in a console is not a check; this is.
+    """
+
+    APP = ROOT / "templates" / "app.js"
+
+    ORDERS = ("ORDER", "COMPACT_ORDER", "PHONE_ORDER", "TINY_ORDER")
+
+    def source(self) -> str:
+        return self.APP.read_text(encoding="utf-8")
+
+    def column_keys(self) -> list[str]:
+        """The `k` of every entry in COLS."""
+        source = self.source()
+        start = source.index("var COLS = [")
+        end = source.index("\n  ];", start)
+        return re.findall(r'\{\s*k:\s*"([^"]+)"', source[start:end])
+
+    def order(self, name: str) -> list[str]:
+        source = self.source()
+        block = re.search(rf"var {name} = \[(.*?)\];", source, re.S)
+        assert block, f"{name} not found in app.js"
+        return re.findall(r'"([^"]+)"', block.group(1))
+
+    def test_columns_were_found(self) -> None:
+        """A guard on the guard: if COLS stops parsing, the rest passes
+        vacuously and the check quietly stops checking."""
+        keys = self.column_keys()
+        self.assertGreater(len(keys), 10, keys)
+        self.assertIn("total", keys)
+
+    def test_every_column_is_placed_at_every_width(self) -> None:
+        keys = set(self.column_keys())
+        for name in self.ORDERS:
+            missing = sorted(keys - set(self.order(name)))
+            self.assertEqual(
+                missing, [],
+                f"{name} does not place {missing}; those columns print last, "
+                f"which on a phone means off the right-hand edge",
+            )
+
+    def test_no_order_names_a_column_that_does_not_exist(self) -> None:
+        """The other direction: a renamed or removed column leaves a dead entry
+        that silently orders nothing."""
+        keys = set(self.column_keys())
+        for name in self.ORDERS:
+            unknown = sorted(set(self.order(name)) - keys)
+            self.assertEqual(unknown, [], f"{name} names columns that are gone: {unknown}")
+
+    def test_the_money_is_never_last(self) -> None:
+        """The Total off the right-hand edge is the failure the phone orders
+        exist to prevent, and it would be silent: the row still renders."""
+        for name in ("PHONE_ORDER", "TINY_ORDER"):
+            order = self.order(name)
+            self.assertLess(order.index("total"), order.index("trip"), name)


### PR DESCRIPTION
The `vs PADI` column from #88 was added to `COLS` and to nothing else, so at all four breakpoints it sorted last. On a laptop that reads as an odd final column; **on a phone it is off the right-hand edge**, which is the device most people open this page on. It shipped that way.

`app.js` predicted this precisely:

> *a column missing from one of these lists is a fact the page stops publishing at that width only, which is the hardest kind of gap to notice — the laptop everyone develops on would look right*

…and guarded it with a `console.warn` nobody sees unless devtools are open. The prediction was right; the guard fired where no one was looking.

## The fix

`padi` now sits after `perdive` in all four orders — `ORDER`, `COMPACT_ORDER`, `PHONE_ORDER`, `TINY_ORDER`. That's where the derived comparisons belong: per-dive and vs-PADI are both read *off* the bill rather than being part of it, so neither goes inside the Advertised → Nitrox → Mandatory → Total sequence the money block is careful to preserve.

## The warning becomes a test

- every `COLS` key appears in every order list
- every order entry names a column that exists, so a rename leaves no dead entry
- on both phone orders the Total still precedes the descriptive columns — the failure those orders exist to prevent, and the one that renders silently

Verified by reintroducing the bug and watching the test name it:

```
PHONE_ORDER does not place ['padi']; those columns print last,
which on a phone means off the right-hand edge
```

621 tests, `promote --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFN6PnZAL4svAiZSMHg2py)_