### PR TITLE
Deploy when any workflow writes the site, not just two of them

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,19 @@ on:
       - "data/**"
       - ".github/workflows/pages.yml"
   workflow_run:
-    workflows: ["Daily refresh", "Weekly fee refresh"]
+    # Every workflow that commits under data/ or site/ belongs here, and the
+    # list is only ever wrong in the silent direction: a data commit lands on
+    # main, nothing fires, and the published page keeps serving an older build
+    # while the repository says it was updated. That is the failure described
+    # above, and it recurred -- three of these were missing. `Read cabin prices
+    # and berths left` writes a berth count that is stale by morning, so a
+    # nightly run whose result never reaches the page is the worst case of it.
+    workflows:
+      - "Daily refresh"
+      - "Weekly fee refresh"
+      - "Read cabin prices and berths left"
+      - "Read trip itineraries"
+      - "Re-promote"
     types: [completed]
   workflow_dispatch:
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1004,3 +1004,68 @@ class TestBothSellersSpan(unittest.TestCase):
         pair = re.search(r"function sellerPair\(lo, hi\) \{(.*?)\n  \}", source, re.S)
         self.assertNotIn("Math.min", pair.group(1))
         self.assertNotIn("Math.max", pair.group(1))
+
+
+class TestEveryDataCommitReachesThePage(unittest.TestCase):
+    """A workflow that commits the published files must trigger the deploy.
+
+    GitHub deliberately does not start a workflow from a push made with the
+    default ``GITHUB_TOKEN``, so `pages.yml`'s `push` trigger never sees a
+    scheduled job's data commit. `workflow_run` is the only trigger that does,
+    and it names the workflows explicitly -- which means the list goes stale
+    every time one is added.
+
+    It fails silently and in the worst direction: the commit lands on main, the
+    repository says the site was updated, and the published page keeps serving
+    an older build. It has already happened once, to three refreshes in a row,
+    and again to three workflows at once. Hence a test rather than a comment.
+    """
+
+    WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+    PUBLISHED = ("data", "site")
+
+    def commits_published_files(self, text: str) -> bool:
+        """Whether the workflow git-adds anything the page is built from."""
+        for line in re.findall(r"^\s*git add\s+(.*)$", text, re.M):
+            for path in re.findall(r"[\w./-]+", line):
+                if path.split("/")[0] in self.PUBLISHED:
+                    return True
+        return False
+
+    def test_the_deploy_watches_every_workflow_that_writes_the_site(self):
+        pages = (self.WORKFLOWS / "pages.yml").read_text(encoding="utf-8")
+        block = re.search(r"workflow_run:(.*?)^  \w", pages, re.S | re.M)
+        self.assertIsNotNone(block, "pages.yml has no workflow_run trigger")
+        watched = set(re.findall(r'"([^"]+)"', block.group(1)))
+
+        missing = []
+        for path in sorted(self.WORKFLOWS.glob("*.yml")):
+            if path.name == "pages.yml":
+                continue
+            text = path.read_text(encoding="utf-8")
+            if not self.commits_published_files(text):
+                continue
+            name = re.search(r"^name:\s*(.+)$", text, re.M)
+            self.assertIsNotNone(name, f"{path.name} has no name:")
+            if name.group(1).strip() not in watched:
+                missing.append(f"{name.group(1).strip()} ({path.name})")
+
+        self.assertEqual(
+            missing, [],
+            "these workflows commit data/ or site/ but do not trigger the "
+            "deploy, so their commits land on main and the published page "
+            f"keeps serving an older build: {missing}",
+        )
+
+    def test_the_watch_list_names_no_workflow_that_does_not_exist(self):
+        """The other direction: a renamed workflow leaves a dead entry that
+        watches nothing, which looks exactly like a watch that works."""
+        pages = (self.WORKFLOWS / "pages.yml").read_text(encoding="utf-8")
+        block = re.search(r"workflow_run:(.*?)^  \w", pages, re.S | re.M)
+        watched = set(re.findall(r'"([^"]+)"', block.group(1)))
+        names = {
+            re.search(r"^name:\s*(.+)$", p.read_text(encoding="utf-8"), re.M).group(1).strip()
+            for p in self.WORKFLOWS.glob("*.yml")
+        }
+        self.assertEqual(sorted(watched - names), [],
+                         "pages.yml watches workflows that no longer exist")


### PR DESCRIPTION
The page for #95 is already live — that merge deployed normally. This fixes a gap found while checking it.

## The gap

`pages.yml` names the workflows whose completion triggers a deploy, because GitHub deliberately does not fire a `push` trigger for a push made with the default `GITHUB_TOKEN`. The list named two: *Daily refresh* and *Weekly fee refresh*.

**Three others commit under `data/` or `site/`** and were not on it:

- `Read cabin prices and berths left`
- `Read trip itineraries`
- `Re-promote`

The failure is silent and in the worst direction: the commit lands on `main`, the repository says the site was updated, and the published page keeps serving an older build. `pages.yml`'s own header documents this happening once before, to three refreshes in a row. It had happened again, to three workflows.

## Why it matters now

The cabin run is the sharpest case, and the reason this surfaced. It is nightly as of yesterday, and what it writes is **a berth count that is stale by morning**. A nightly figure whose result never reaches the page is worse than not collecting it — the repo would have looked healthy while the site served Thursday's counts indefinitely.

## Tested, not commented

Two tests, in both directions:

- every workflow that `git add`s a published path must appear in the watch list;
- the watch list must name no workflow that does not exist — a renamed workflow leaves a dead entry that watches nothing and looks exactly like a watch that works.

The header comment had already explained this failure mode once and did not prevent its recurrence, which is the argument for a test rather than a longer comment.

663 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_