### PR TITLE
Pin the method panel's heading, and close it where you opened it

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -467,13 +467,25 @@ tr.detail td { background:var(--ground); padding:12px 18px; white-space:normal; 
   border-top:1px solid var(--rule); background:var(--panel); color:var(--ink-dim);
   max-height:52vh; overflow:auto;
 }
+/* Pinned to the top of the panel's own scroll box, which is what the box
+   already is: 52vh with overflow:auto. Without this the only control that
+   closes the section scrolls away with the first paragraph, so shutting it
+   again means scrolling back through everything you just read.
+
+   It needs its own opaque background: the panel's is on the box behind, and a
+   sticky element without one has the content sliding through it. */
 .site-footer > summary {
+  position:sticky; top:0; z-index:2; background:var(--panel);
   padding:9px 18px; cursor:pointer; list-style:none;
   font-family:var(--font-narrow);
   font-size:11px; text-transform:uppercase; letter-spacing:.09em;
   color:var(--ink-faint); font-weight:600;
   display:flex; gap:14px; align-items:baseline;
 }
+/* A rule under it only while there is something to be above. Closed, the
+   summary is the bottom edge of the page and a second line there is one
+   border too many. */
+.site-footer[open] > summary { border-bottom:1px solid var(--rule); }
 .site-footer > summary::-webkit-details-marker { display:none; }
 .site-footer > summary::before { content:"▸"; color:var(--accent); }
 .site-footer[open] > summary::before { content:"▾"; }
@@ -2934,6 +2946,28 @@ fees (14)
   });
 
   labelFilters();
+
+  /* Closing the method panel puts the reader back at its heading.
+   *
+   * The panel scrolls inside itself, and its summary is pinned to the top of
+   * that box, so it can be shut from wherever you got to. Two things are then
+   * wrong if nothing is done. The box keeps the scroll position it had, so
+   * reopening it drops you back into the middle of a paragraph you had
+   * finished with. And the page may be scrolled to where the panel filled the
+   * screen a moment ago, which after it collapses to one line is blank space
+   * under the table.
+   *
+   * `nearest` rather than a jump to the top: when the heading is already on
+   * screen -- which it is whenever the panel was opened without scrolling --
+   * the right amount of movement is none. */
+  var method = document.querySelector(".site-footer");
+  if (method) {
+    method.addEventListener("toggle", function () {
+      if (method.open) return;
+      method.scrollTop = 0;
+      method.scrollIntoView({ block: "nearest" });
+    });
+  }
 
   document.getElementById("metaLine").textContent =
     D.meta.counts.departures.toLocaleString("en-IE") + " departures · " +

--- a/templates/app.js
+++ b/templates/app.js
@@ -1749,6 +1749,28 @@
 
   labelFilters();
 
+  /* Closing the method panel puts the reader back at its heading.
+   *
+   * The panel scrolls inside itself, and its summary is pinned to the top of
+   * that box, so it can be shut from wherever you got to. Two things are then
+   * wrong if nothing is done. The box keeps the scroll position it had, so
+   * reopening it drops you back into the middle of a paragraph you had
+   * finished with. And the page may be scrolled to where the panel filled the
+   * screen a moment ago, which after it collapses to one line is blank space
+   * under the table.
+   *
+   * `nearest` rather than a jump to the top: when the heading is already on
+   * screen -- which it is whenever the panel was opened without scrolling --
+   * the right amount of movement is none. */
+  var method = document.querySelector(".site-footer");
+  if (method) {
+    method.addEventListener("toggle", function () {
+      if (method.open) return;
+      method.scrollTop = 0;
+      method.scrollIntoView({ block: "nearest" });
+    });
+  }
+
   document.getElementById("metaLine").textContent =
     D.meta.counts.departures.toLocaleString("en-IE") + " departures · " +
     /* "bookable by the berth", not "boats in Egypt" — charter-only vessels are

--- a/templates/style.css
+++ b/templates/style.css
@@ -460,13 +460,25 @@ tr.detail td { background:var(--ground); padding:12px 18px; white-space:normal; 
   border-top:1px solid var(--rule); background:var(--panel); color:var(--ink-dim);
   max-height:52vh; overflow:auto;
 }
+/* Pinned to the top of the panel's own scroll box, which is what the box
+   already is: 52vh with overflow:auto. Without this the only control that
+   closes the section scrolls away with the first paragraph, so shutting it
+   again means scrolling back through everything you just read.
+
+   It needs its own opaque background: the panel's is on the box behind, and a
+   sticky element without one has the content sliding through it. */
 .site-footer > summary {
+  position:sticky; top:0; z-index:2; background:var(--panel);
   padding:9px 18px; cursor:pointer; list-style:none;
   font-family:var(--font-narrow);
   font-size:11px; text-transform:uppercase; letter-spacing:.09em;
   color:var(--ink-faint); font-weight:600;
   display:flex; gap:14px; align-items:baseline;
 }
+/* A rule under it only while there is something to be above. Closed, the
+   summary is the bottom edge of the page and a second line there is one
+   border too many. */
+.site-footer[open] > summary { border-bottom:1px solid var(--rule); }
 .site-footer > summary::-webkit-details-marker { display:none; }
 .site-footer > summary::before { content:"▸"; color:var(--accent); }
 .site-footer[open] > summary::before { content:"▾"; }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1069,3 +1069,54 @@ class TestEveryDataCommitReachesThePage(unittest.TestCase):
         }
         self.assertEqual(sorted(watched - names), [],
                          "pages.yml watches workflows that no longer exist")
+
+
+class TestTheMethodPanelCanBeClosedFromAnywhere(unittest.TestCase):
+    """The footer scrolls inside itself, so its own heading must stay reachable.
+
+    `.site-footer` is `max-height:52vh; overflow:auto` — a scroll box, not a
+    page section. Without a pinned summary the only control that closes it
+    scrolls away with the first paragraph, and shutting it again means
+    scrolling back through everything you just read.
+
+    Both halves are asserted because either alone is useless: the sticky rule
+    without an opaque background has the text sliding through the heading, and
+    the sticky heading without the toggle handler leaves the panel holding a
+    stale scroll position and the reader in blank space under the table.
+    """
+
+    CSS = Path(__file__).resolve().parents[1] / "templates" / "style.css"
+    APP = Path(__file__).resolve().parents[1] / "templates" / "app.js"
+
+    def summary_rule(self) -> str:
+        css = self.CSS.read_text(encoding="utf-8")
+        match = re.search(r"\.site-footer > summary \{(.*?)\}", css, re.S)
+        self.assertIsNotNone(match, "the footer summary has no rule of its own")
+        return match.group(1)
+
+    def test_the_panel_is_its_own_scroll_box(self):
+        """The premise. If this stops being true the sticky heading is
+        pointless and the toggle handler is resetting nothing."""
+        css = self.CSS.read_text(encoding="utf-8")
+        rule = re.search(r"\.site-footer \{(.*?)\}", css, re.S)
+        self.assertIsNotNone(rule)
+        self.assertIn("overflow:auto", rule.group(1).replace(" ", ""))
+
+    def test_the_heading_is_pinned(self):
+        rule = self.summary_rule().replace(" ", "")
+        self.assertIn("position:sticky", rule)
+        self.assertIn("top:0", rule)
+
+    def test_the_pinned_heading_is_opaque(self):
+        """A sticky element without its own background has the content
+        scrolling visibly through it — the panel's background is on the box
+        behind, not on the heading."""
+        self.assertIn("background", self.summary_rule())
+
+    def test_closing_it_resets_the_panel_and_returns_to_the_heading(self):
+        source = self.APP.read_text(encoding="utf-8")
+        self.assertIn('.site-footer', source, "app.js never finds the panel")
+        self.assertIn("scrollTop = 0", source,
+                      "closing leaves a stale scroll position inside the panel")
+        self.assertIn("scrollIntoView", source,
+                      "closing can leave the reader in blank space below the table")


### PR DESCRIPTION
"How the numbers are built" is already a scroll box rather than a page section — `max-height: 52vh; overflow: auto`, so it takes only as much of the table's room as it needs. Its heading is also the only control that closes it, and that heading scrolled away with the first paragraph: shutting the panel again meant scrolling back up through everything you had just read.

## Pinned

The summary is now `position: sticky; top: 0` against the panel's own scroll box.

It needs **a background of its own** — the panel's is on the box behind it, and a sticky element without one has the text sliding visibly through it. The rule under it appears only while the panel is open; closed, the summary is the bottom edge of the page and a second line there is one border too many.

## Closing

Two loose ends once the panel can be shut from anywhere:

- **The box kept its scroll position**, so reopening dropped the reader into the middle of a paragraph they had finished with.
- **The page could be scrolled to where the panel filled the screen** a moment earlier, which after it collapses to one line is blank space under the table.

Closing now resets the box and brings the heading back into view — `scrollIntoView({block: "nearest"})`, so a panel that was opened without scrolling does not move at all. The right amount of movement, when the heading is already on screen, is none.

## Checked

In a browser at 390px and 1400px, in both themes: heading pinned while scrolled 2,054px into the panel, opaque in each theme (`rgb(255,255,255)` / `rgb(19,26,35)`), and back on screen after closing with the box reset to 0.

Four guards added. Both halves are asserted because either alone is useless: the sticky rule without an opaque background has text sliding through the heading, and the sticky heading without the toggle handler leaves a stale scroll position and the reader in blank space. One guards the premise — that the panel is a scroll box at all — since if that stops being true the other three are protecting nothing.

667 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFckrML9xXg9sydCRXKdPK)_